### PR TITLE
Allow getting unresolved objects

### DIFF
--- a/fendermint/app/src/cmd/proxy.rs
+++ b/fendermint/app/src/cmd/proxy.rs
@@ -327,11 +327,12 @@ async fn handle_os_get(
                     message: format!("failed to decode value: {}", e),
                 })
             })?;
-            if !obj.resolved {
-                return Err(Rejection::from(BadRequest {
-                    message: "object is not resolved".to_string(),
-                }));
-            }
+            // TODO: Uncomment this check when object voting is implemented.
+            // if !obj.resolved {
+            //     return Err(Rejection::from(BadRequest {
+            //         message: "object is not resolved".to_string(),
+            //     }));
+            // }
             let val = value.to_string();
 
             let stat = ipfs.object_links(&val).await.map_err(|e| {

--- a/infra/fendermint/scripts/proxy.toml
+++ b/infra/fendermint/scripts/proxy.toml
@@ -11,7 +11,7 @@ docker run \
   --env FM_CHAIN_NAME=${SUBNET_ID} \
   --env FM_PROXY_SECRET_KEY=/data/${NODE_NAME}/${PROXY_PRIV_KEY_PATH} \
   --env FM_PROXY_ACCOUNT_KIND=ethereum \
-  --env FM_PROXY_BROADCAST_MODE=async \
+  --env FM_PROXY_BROADCAST_MODE=sync \
   --env FM_PROXY_SEQUENCE=0 \
   --env TENDERMINT_RPC_URL=http://${CMT_CONTAINER_NAME}:26657 \
   --env IPFS_RPC_ADDR=/dns4/${IPFS_CONTAINER_NAME}/tcp/5001 \


### PR DESCRIPTION
Until https://github.com/28657/ipc/issues/16 is done, we can allow the proxy to fetch objects and ranges in objects. The nodes currently do resolve objects from each other, but until there is a mechanism by which the leader can determine if everyone has the object (not just themselves) before proposing a txn that marks it as resolved, the lazy sync flow doesn't work... nodes will reject the proposal if they aren't done resolving. It works fine on a single node deployment.