### PR TITLE
Adds support for getting values by index from the accumulator

### DIFF
--- a/fendermint/actors/accumulator/src/shared.rs
+++ b/fendermint/actors/accumulator/src/shared.rs
@@ -8,6 +8,7 @@ use fvm_ipld_amt::Amt;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{
     de::DeserializeOwned,
+    from_slice,
     ser::Serialize,
     to_vec,
     tuple::{Deserialize_tuple, Serialize_tuple},
@@ -75,7 +76,7 @@ fn push<BS: Blockstore, S: DeserializeOwned + Serialize>(
     let leaf = store.put_cbor(&obj, Code::Blake2b256)?;
     // Push the new leaf onto the peaks
     peaks.set(peaks.count(), leaf)?;
-    // Count trailing ones in the binary representation of leaf_count + 1
+    // Count trailing ones in binary representation of the previous leaf_count
     // This works because adding a leaf fills the next available spot,
     // and the binary representation of this index will have trailing ones
     // where merges are required.
@@ -97,17 +98,98 @@ fn push<BS: Blockstore, S: DeserializeOwned + Serialize>(
 /// Collect the peaks and combine to compute the root commitment.
 fn bag_peaks<BS: Blockstore>(peaks: &Amt<Cid, &BS>) -> anyhow::Result<Cid> {
     let peaks_count = peaks.count();
+    // Handle special cases where we have no peaks or only one peak
     if peaks_count == 0 {
         return Ok(Cid::default());
     }
+    // If there is only one leaf element, we simply "promote" that to the root peak
     if peaks_count == 1 {
         return Ok(peaks.get(0)?.unwrap().to_owned());
     }
+    // Walk backward through the peaks, combining them pairwise
     let mut root = hash_pair(peaks.get(peaks_count - 2)?, peaks.get(peaks_count - 1)?)?;
     for i in 2..peaks_count {
         root = hash_pair(peaks.get(peaks_count - 1 - i)?, Some(&root))?;
     }
     Ok(root)
+}
+
+fn path_for_eigen_root(leaf_index: u64, leaf_count: u64) -> (u64, u32) {
+    // Ensure `leaf_index` is within bounds.
+    assert!(
+        leaf_index < leaf_count,
+        "`leaf_index` must less than `leaf_count`"
+    );
+    // XOR turns matching bits into zeros and differing bits into ones, so to determine when
+    // the two "paths" converge, we simply look for the most significant 1 bit...
+    let diff = leaf_index ^ leaf_count;
+    // ...and then merge height of `leaf_index` and `leaf_count` occurs at ⌊log2(x ⊕ y)⌋
+    let eigentree_height = u64::BITS - diff.leading_zeros() - 1;
+    let merge_height = 1 << eigentree_height;
+    // Compute a bitmask (all the lower bits set to 1)
+    let bitmask = merge_height - 1;
+    // The Hamming weight of leaf_count is the number of eigentrees in the structure.
+    let eigentree_count = leaf_count.count_ones();
+    // Isolates the lower bits of leaf_count up to the merge_height, and count the one bits.
+    // This is essentially the offset to the eigentree containing leaf_index
+    let offset = (leaf_count & bitmask).count_ones();
+    // The index is simply the total eigentree count minus the offset (minus one)
+    let index = eigentree_count - offset - 1;
+    // Now that we have the offset, we need to determine the path within the local eigentree
+    let local_offset = leaf_index & bitmask;
+    // The local_index is the local_offset plus the merge_height for the local eigentree
+    let local_index = local_offset + merge_height;
+    (local_index, index as u32)
+}
+
+fn get_at<BS: Blockstore, S: DeserializeOwned + Serialize>(
+    store: &BS,
+    leaf_index: u64,
+    leaf_count: u64,
+    peaks: &Amt<Cid, &BS>,
+) -> anyhow::Result<S> {
+    let (path, eigen_index) = path_for_eigen_root(leaf_index, leaf_count);
+    let cid = match peaks.get(eigen_index as u64)? {
+        Some(cid) => cid,
+        None => {
+            return Err(anyhow::anyhow!(
+                "failed to get peak at index {}",
+                eigen_index
+            ))
+        }
+    };
+    // Special case where eigentree has height of one
+    if path == 1 {
+        return match store.get_cbor::<S>(cid)? {
+            Some(value) => Ok(value),
+            None => return Err(anyhow::anyhow!("failed to get root for cid {}", cid)),
+        };
+    }
+    let mut root = match store.get_cbor::<Vec<u8>>(cid)? {
+        Some(value) => value,
+        None => return Err(anyhow::anyhow!("failed to get root for cid {}", cid)),
+    };
+    let mut pair = from_slice::<[Cid; 2]>(&root)?;
+
+    let leading_zeros = path.leading_zeros();
+    let significant_bits = 64 - leading_zeros;
+
+    // Iterate over each bit from the most significant bit to the least
+    for i in 1..(significant_bits - 1) {
+        let bit = ((path >> (significant_bits - i - 1)) & 1) as usize;
+        root = match store.get_cbor(&pair[bit])? {
+            Some(root) => root,
+            None => return Err(anyhow::anyhow!("failed to get root at index {}", bit)),
+        };
+        pair = from_slice::<[Cid; 2]>(&root)?;
+    }
+
+    let bit = (path & 1) as usize;
+    let leaf = match store.get_cbor::<S>(&pair[bit])? {
+        Some(root) => root,
+        None => return Err(anyhow::anyhow!("failed to get root at index {}", bit)),
+    };
+    Ok(leaf)
 }
 
 // The state represents an mmr with peaks stored in an Amt
@@ -132,6 +214,14 @@ impl State {
             peaks,
             leaf_count: 0,
         })
+    }
+
+    pub fn peak_count(&self) -> u32 {
+        self.leaf_count.count_ones()
+    }
+
+    pub fn leaf_count(&self) -> u64 {
+        self.leaf_count
     }
 
     pub fn push<BS: Blockstore, S: DeserializeOwned + Serialize>(
@@ -160,6 +250,15 @@ impl State {
         })?;
         Ok(peaks)
     }
+
+    pub fn get_obj<BS: Blockstore, S: DeserializeOwned + Serialize>(
+        &self,
+        store: &BS,
+        index: u64,
+    ) -> anyhow::Result<S> {
+        let amt = Amt::<Cid, &BS>::load(&self.peaks, store)?;
+        get_at::<BS, S>(store, index, self.leaf_count, &amt)
+    }
 }
 
 #[cfg(test)]
@@ -178,7 +277,7 @@ mod tests {
             Cid::from_str("bafy2bzacedijw74yui7otvo63nfl3hdq2vdzuy7wx2tnptwed6zml4vvz7wee")
                 .unwrap()
         );
-        assert_eq!(state.leaf_count, 0);
+        assert_eq!(state.leaf_count(), 0);
     }
 
     #[test]
@@ -190,7 +289,7 @@ mod tests {
             state.push(&store, obj).expect("push failed"),
             state.get_root(&store).expect("get_root failed")
         );
-        assert_eq!(state.leaf_count, 1);
+        assert_eq!(state.leaf_count(), 1);
     }
 
     #[test]
@@ -199,7 +298,7 @@ mod tests {
         let mut state = State::new(&store).unwrap();
         let obj = vec![1, 2, 3];
         assert!(state.push(&store, obj).is_ok());
-        assert_eq!(state.leaf_count, 1);
+        assert_eq!(state.leaf_count(), 1);
         let peaks = state.get_peaks(&store);
         assert!(peaks.is_ok());
         let peaks = peaks.unwrap();
@@ -215,20 +314,29 @@ mod tests {
     fn test_bag_peaks() {
         let store = fvm_ipld_blockstore::MemoryBlockstore::default();
         let mut state = State::new(&store).unwrap();
-        state.push(&store, vec![1]).unwrap();
-        state.push(&store, vec![2]).unwrap();
-        state.push(&store, vec![3]).unwrap();
-        state.push(&store, vec![4]).unwrap();
-        state.push(&store, vec![5]).unwrap();
-        state.push(&store, vec![6]).unwrap();
-        state.push(&store, vec![7]).unwrap();
-        state.push(&store, vec![8]).unwrap();
-        state.push(&store, vec![9]).unwrap();
-        state.push(&store, vec![10]).unwrap();
-        let root = state.push(&store, vec![11]).unwrap();
+        let mut root = Cid::default();
+        for i in 1..=11 {
+            root = state.push(&store, vec![i]).unwrap();
+        }
         let peaks = state.get_peaks(&store).unwrap();
         assert_eq!(peaks.len(), 3);
-        assert_eq!(state.leaf_count, 11);
+        assert_eq!(state.leaf_count(), 11);
         assert_eq!(root, state.get_root(&store).expect("get_root failed"));
+    }
+
+    #[test]
+    fn test_get_obj() {
+        let store = fvm_ipld_blockstore::MemoryBlockstore::default();
+        let mut state = State::new(&store).unwrap();
+        for i in 0..31 {
+            state.push(&store, vec![i]).unwrap();
+        }
+        assert_eq!(state.peak_count(), 5);
+        assert_eq!(state.leaf_count(), 31);
+
+        for i in 0..31 {
+            let item = state.get_obj::<_, Vec<i32>>(&store, i as u64).unwrap();
+            assert_eq!(item, vec![i]);
+        }
     }
 }


### PR DESCRIPTION
This is really just a fake PR to get the code up somewhere for posterity. I've stripped out all rpc methods etc, and am just including the core functionality.

This provides a 'get by index' mechanism with no additional storage overhead, which is pretty cool. But since we aren't going to use this code per se, I'll close this PR right away.