### PR TITLE
test that demonstrates disagreement between methods of Cid generation

### DIFF
--- a/fendermint/actors/accumulator/src/shared.rs
+++ b/fendermint/actors/accumulator/src/shared.rs
@@ -182,6 +182,23 @@ mod tests {
     }
 
     #[test]
+    fn test_hash_pair() {
+        let store = fvm_ipld_blockstore::MemoryBlockstore::default();
+        let mut state = State::new(&store).unwrap();
+
+        let obj1 = vec![1, 2, 3];
+        let obj2 = vec![1, 2, 3];
+        let cid1 = state.push(&store, obj1).expect("push1 failed");
+        let cid2 = state.push(&store, obj2).expect("push2 failed");
+
+        // Compare hash_pair and hash_and_put_pair and make sure they result in the same CID.
+        let hash1 = hash_pair(Some(&cid1), Some(&cid2)).expect("hash_pair failed");
+        let hash2 =
+            hash_and_put_pair(&store, Some(&cid1), Some(&cid2)).expect("hash_and_put_pair failed");
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
     fn test_push_simple() {
         let store = fvm_ipld_blockstore::MemoryBlockstore::default();
         let mut state = State::new(&store).unwrap();


### PR DESCRIPTION
This test demonstrates the fact that the `hash_pair` and `hash_and_put_pair` functions do not return the same CID, even when given the same input.

This suggests that at least one of them is doing the wrong thing.

Test failure:
```
thread 'shared::tests::test_hash_pair' panicked at fendermint/actors/accumulator/src/shared.rs:198:9:
assertion `left == right` failed
  left: Cid(bafy2bzacecegdy53s6ugzevrir3tykqx33ydrabcgaro4vqf223zqkyd3oivg)
 right: Cid(bafy2bzacecdkognmmxx6m6dql5jlssapbbnab6imtmnoxpfwtbsgaavdetfjc)
stack backtrace:
   0: rust_begin_unwind
             at /rustc/7cf61ebde7b22796c69757901dd346d0fe70bd97/library/std/src/panicking.rs:647:5
   1: core::panicking::panic_fmt
             at /rustc/7cf61ebde7b22796c69757901dd346d0fe70bd97/library/core/src/panicking.rs:72:14
   2: core::panicking::assert_failed_inner
   3: core::panicking::assert_failed
             at /rustc/7cf61ebde7b22796c69757901dd346d0fe70bd97/library/core/src/panicking.rs:297:5
   4: fendermint_actor_accumulator::shared::tests::test_hash_pair
             at ./src/shared.rs:198:9
   5: fendermint_actor_accumulator::shared::tests::test_hash_pair::{{closure}}
             at ./src/shared.rs:185:24
   6: core::ops::function::FnOnce::call_once
             at /rustc/7cf61ebde7b22796c69757901dd346d0fe70bd97/library/core/src/ops/function.rs:250:5
   7: core::ops::function::FnOnce::call_once
             at /rustc/7cf61ebde7b22796c69757901dd346d0fe70bd97/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```