### PR TITLE
fix: Don't encode array of cids as an IPLD vector before putting into the store

### DIFF
--- a/fendermint/actors/accumulator/src/shared.rs
+++ b/fendermint/actors/accumulator/src/shared.rs
@@ -192,10 +192,10 @@ mod tests {
         let pair_cid =
             hash_and_put_pair(&store, Some(&cid1), Some(&cid2)).expect("hash_and_put_pair failed");
         let merkle_node = store
-            .get(&pair_cid)
-            .expect("get failed")
-            .expect("get returned none");
-        let expected = to_vec(&[cid1, cid2]).expect("encoding merkle node failed");
+            .get_cbor::<[Cid; 2]>(&pair_cid)
+            .expect("get_cbor failed")
+            .expect("get_cbor returned None");
+        let expected = [cid1, cid2];
         assert_eq!(merkle_node, expected);
     }
 


### PR DESCRIPTION
This is redundant since it is already done when putting objects into the CborStore: https://github.com/filecoin-project/ref-fvm/blob/464bba53ad01391452db605002c9b5cca189fe39/ipld/encoding/src/cbor_store.rs#L34

^ it does seem kind of weird though that the CborStore always encodes all data it is getting into a vector.  I wonder if a better fix would be for the CborStore to take its input as already encoded as Ipld, so the caller can decide how the data should be represented in IPLD.

See https://github.com/amazingdatamachine/ipc/pull/53 for how I discovered this issue.