### PR TITLE
feat: get values by index in accumulator

### DIFF
--- a/fendermint/actors/accumulator/src/actor.rs
+++ b/fendermint/actors/accumulator/src/actor.rs
@@ -45,6 +45,13 @@ impl Actor {
         })
     }
 
+    fn get_leaf_at(rt: &impl Runtime, index: u64) -> Result<Vec<u8>, ActorError> {
+        rt.validate_immediate_caller_accept_any()?;
+        let st: State = rt.state()?;
+        st.get_obj(rt.store(), index)
+            .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to get leaf"))
+    }
+
     fn get_root(rt: &impl Runtime) -> Result<Cid, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let st: State = rt.state()?;
@@ -90,6 +97,7 @@ impl ActorCode for Actor {
     actor_dispatch! {
         Constructor => constructor,
         Push => push,
+        Get => get_leaf_at,
         Root => get_root,
         Peaks => get_peaks,
         Count => get_count,

--- a/fendermint/actors/accumulator/src/shared.rs
+++ b/fendermint/actors/accumulator/src/shared.rs
@@ -24,6 +24,7 @@ const BIT_WIDTH: u32 = 3;
 pub enum Method {
     Constructor = METHOD_CONSTRUCTOR,
     Push = frc42_dispatch::method_hash!("Push"),
+    Get = frc42_dispatch::method_hash!("Get"),
     Root = frc42_dispatch::method_hash!("Root"),
     Peaks = frc42_dispatch::method_hash!("Peaks"),
     Count = frc42_dispatch::method_hash!("Count"),


### PR DESCRIPTION
First commit is exactly Carson's original commit from the `carson/get_at` branch.  Then my fix to make the tests pass with the changes from https://github.com/amazingdatamachine/ipc/pull/54 is a separate commit on top, if you want to just view those changes independently you can see them here: [`30c02ca` (#58)](https://github.com/amazingdatamachine/ipc/pull/58/commits/30c02cab4f5ca97e729d732012874a49cbebeee3).  Then there's a final commit that is just some changes to error messages.