### PR TITLE
Point to the deployment repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Visit the [IPC project page](https://www.ipc.space/) for news and guides.
 
 ## Prerequisites
 
+Alternatively, you may use the [Ansible deployment](https://github.com/amazingdatamachine/ipc-deploy)
+
 On Linux (links and instructions for Ubuntu):
 
 - Install system packages: `sudo apt install build-essential clang cmake pkg-config libssl-dev protobuf-compiler git curl`.


### PR DESCRIPTION
We should not merge this until the final public repo name, i think.  Just opening it to make clear where the deployment work is proceeding:  in https://github.com/amazingdatamachine/ipc-deploy