### PR TITLE
Add typechain exports, upgrade to ethers v6

### DIFF
--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -36,3 +36,6 @@ report.json
 
 #vim
 *.un~
+
+hardhat.config.d*
+hardhat.config.js*

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -1,5 +1,5 @@
 import '@nomicfoundation/hardhat-foundry'
-import '@nomiclabs/hardhat-ethers'
+import '@nomicfoundation/hardhat-ethers'
 import '@typechain/hardhat'
 import * as fs from 'fs'
 import 'hardhat-contract-sizer'
@@ -283,6 +283,7 @@ task(
     async (args, hre: HardhatRuntimeEnvironment) => {
         await hre.run('compile')
         const network = hre.network.name
+        // @ts-expect-error allow accessing unknown args
         if (!args.address) {
             console.error(
                 'No address provided. Usage: npx hardhat upgrade-sa-diamond --address 0x80afa...',
@@ -290,6 +291,7 @@ task(
             process.exit(1)
         }
 
+        // @ts-expect-error allow accessing unknown args
         const deployments = await readSubnetActor(args.address, network)
 
         const { upgradeDiamond } = await lazyImport(
@@ -298,6 +300,7 @@ task(
         const updatedFacets = await upgradeDiamond(deployments)
         await saveSubnetActor(deployments, updatedFacets)
     },
+    // @ts-expect-error allow accessing unknown args
 ).addParam('address', 'The address to upgrade', undefined, types.string, false)
 
 /** @type import('hardhat/config').HardhatUserConfig */
@@ -346,7 +349,7 @@ const config: HardhatUserConfig = {
     },
     typechain: {
         outDir: 'typechain',
-        target: 'ethers-v5',
+        target: 'ethers-v6',
     },
     paths: {
         storageLayouts: '.storage-layouts',

--- a/contracts/package-lock.json
+++ b/contracts/package-lock.json
@@ -16,19 +16,19 @@
                 "hardhat-storage-layout-changes": "^0.1.2"
             },
             "devDependencies": {
-                "@nomicfoundation/hardhat-foundry": "^1.0.1",
-                "@nomiclabs/hardhat-ethers": "^2.2.3",
-                "@openzeppelin/contracts": "5.0.1",
-                "@typechain/ethers-v5": "^11.1.2",
-                "@typechain/hardhat": "^7.0.0",
+                "@nomicfoundation/hardhat-ethers": "^3.0.6",
+                "@nomicfoundation/hardhat-foundry": "^1.1.2",
+                "@openzeppelin/contracts": "^5.0.1",
+                "@typechain/ethers-v6": "^0.5.1",
+                "@typechain/hardhat": "^9.1.0",
                 "dotenv": "^16.0.1",
                 "elliptic-curve-solidity": "github:witnet/elliptic-curve-solidity#3475478",
-                "ethers": "^5.7.0",
+                "ethers": "^6.13.2",
                 "fevmate": "github:wadealexc/fevmate#6a80e98",
                 "fs-extra": "^11.2.0",
-                "hardhat-contract-sizer": "^2.6.1",
-                "hardhat-deploy": "^0.11.14",
-                "hardhat-deploy-ethers": "^0.3.0-beta.13",
+                "hardhat-contract-sizer": "^2.10.0",
+                "hardhat-deploy": "^0.12.4",
+                "hardhat-deploy-ethers": "^0.4.2",
                 "husky": "^8.0.3",
                 "lint-staged": "^15.0.2",
                 "prettier": "^2.8.8",
@@ -37,8 +37,15 @@
                 "solhint-plugin-prettier": "^0.0.5",
                 "ts-node": "^10.9.1",
                 "typechain": "^8.3.2",
-                "typescript": "^4.8.3"
+                "typescript": "^5.5.4"
             }
+        },
+        "node_modules/@adraffy/ens-normalize": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+            "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.23.4",
@@ -710,6 +717,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "@ethersproject/bignumber": "^5.7.0",
                 "@ethersproject/constants": "^5.7.0",
@@ -840,6 +848,32 @@
                 "node": ">=12.0.0"
             }
         },
+        "node_modules/@noble/curves": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+            "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "1.3.2"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/curves/node_modules/@noble/hashes": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+            "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@noble/hashes": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
@@ -899,6 +933,54 @@
                 "scrypt-js": "^3.0.0",
                 "secp256k1": "^4.0.1",
                 "setimmediate": "^1.0.5"
+            }
+        },
+        "node_modules/@nomicfoundation/ethereumjs-block/node_modules/ethers": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+            "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abi": "5.7.0",
+                "@ethersproject/abstract-provider": "5.7.0",
+                "@ethersproject/abstract-signer": "5.7.0",
+                "@ethersproject/address": "5.7.0",
+                "@ethersproject/base64": "5.7.0",
+                "@ethersproject/basex": "5.7.0",
+                "@ethersproject/bignumber": "5.7.0",
+                "@ethersproject/bytes": "5.7.0",
+                "@ethersproject/constants": "5.7.0",
+                "@ethersproject/contracts": "5.7.0",
+                "@ethersproject/hash": "5.7.0",
+                "@ethersproject/hdnode": "5.7.0",
+                "@ethersproject/json-wallets": "5.7.0",
+                "@ethersproject/keccak256": "5.7.0",
+                "@ethersproject/logger": "5.7.0",
+                "@ethersproject/networks": "5.7.1",
+                "@ethersproject/pbkdf2": "5.7.0",
+                "@ethersproject/properties": "5.7.0",
+                "@ethersproject/providers": "5.7.2",
+                "@ethersproject/random": "5.7.0",
+                "@ethersproject/rlp": "5.7.0",
+                "@ethersproject/sha2": "5.7.0",
+                "@ethersproject/signing-key": "5.7.0",
+                "@ethersproject/solidity": "5.7.0",
+                "@ethersproject/strings": "5.7.0",
+                "@ethersproject/transactions": "5.7.0",
+                "@ethersproject/units": "5.7.0",
+                "@ethersproject/wallet": "5.7.0",
+                "@ethersproject/web": "5.7.1",
+                "@ethersproject/wordlists": "5.7.0"
             }
         },
         "node_modules/@nomicfoundation/ethereumjs-blockchain": {
@@ -1092,6 +1174,54 @@
                 "setimmediate": "^1.0.5"
             }
         },
+        "node_modules/@nomicfoundation/ethereumjs-statemanager/node_modules/ethers": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+            "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abi": "5.7.0",
+                "@ethersproject/abstract-provider": "5.7.0",
+                "@ethersproject/abstract-signer": "5.7.0",
+                "@ethersproject/address": "5.7.0",
+                "@ethersproject/base64": "5.7.0",
+                "@ethersproject/basex": "5.7.0",
+                "@ethersproject/bignumber": "5.7.0",
+                "@ethersproject/bytes": "5.7.0",
+                "@ethersproject/constants": "5.7.0",
+                "@ethersproject/contracts": "5.7.0",
+                "@ethersproject/hash": "5.7.0",
+                "@ethersproject/hdnode": "5.7.0",
+                "@ethersproject/json-wallets": "5.7.0",
+                "@ethersproject/keccak256": "5.7.0",
+                "@ethersproject/logger": "5.7.0",
+                "@ethersproject/networks": "5.7.1",
+                "@ethersproject/pbkdf2": "5.7.0",
+                "@ethersproject/properties": "5.7.0",
+                "@ethersproject/providers": "5.7.2",
+                "@ethersproject/random": "5.7.0",
+                "@ethersproject/rlp": "5.7.0",
+                "@ethersproject/sha2": "5.7.0",
+                "@ethersproject/signing-key": "5.7.0",
+                "@ethersproject/solidity": "5.7.0",
+                "@ethersproject/strings": "5.7.0",
+                "@ethersproject/transactions": "5.7.0",
+                "@ethersproject/units": "5.7.0",
+                "@ethersproject/wallet": "5.7.0",
+                "@ethersproject/web": "5.7.1",
+                "@ethersproject/wordlists": "5.7.0"
+            }
+        },
         "node_modules/@nomicfoundation/ethereumjs-trie": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-6.0.2.tgz",
@@ -1264,11 +1394,27 @@
                 "setimmediate": "^1.0.5"
             }
         },
-        "node_modules/@nomicfoundation/hardhat-foundry": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-foundry/-/hardhat-foundry-1.1.1.tgz",
-            "integrity": "sha512-cXGCBHAiXas9Pg9MhMOpBVQCkWRYoRFG7GJJAph+sdQsfd22iRs5U5Vs9XmpGEQd1yEvYISQZMeE68Nxj65iUQ==",
+        "node_modules/@nomicfoundation/hardhat-ethers": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.0.6.tgz",
+            "integrity": "sha512-/xzkFQAaHQhmIAYOQmvHBPwL+NkwLzT9gRZBsgWUYeV+E6pzXsBQsHfRYbAZ3XEYare+T7S+5Tg/1KDJgepSkA==",
             "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.1.1",
+                "lodash.isequal": "^4.5.0"
+            },
+            "peerDependencies": {
+                "ethers": "^6.1.0",
+                "hardhat": "^2.0.0"
+            }
+        },
+        "node_modules/@nomicfoundation/hardhat-foundry": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-foundry/-/hardhat-foundry-1.1.2.tgz",
+            "integrity": "sha512-f5Vhj3m2qvKGpr6NAINYwNgILDsai8dVCsFb1rAVLkJxOmD2pAtfCmOH5SBVr9yUI5B1z9rbTwPBJVrqnb+PXQ==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "chalk": "^2.4.2"
             },
@@ -1446,21 +1592,12 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/@nomiclabs/hardhat-ethers": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.2.3.tgz",
-            "integrity": "sha512-YhzPdzb612X591FOe68q+qXVXGG2ANZRvDo0RRUtimev85rCrAlv/TLMEZw5c+kq9AbzocLTVX/h2jVIFPL9Xg==",
-            "dev": true,
-            "peerDependencies": {
-                "ethers": "^5.0.0",
-                "hardhat": "^2.0.0"
-            }
-        },
         "node_modules/@openzeppelin/contracts": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.0.1.tgz",
             "integrity": "sha512-yQJaT5HDp9hYOOp4jTYxMsR02gdFZFXhewX5HW9Jo4fsqSVqqyIO/xTHdWDaKX5a3pv1txmf076Lziz+sO7L1w==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@scure/base": {
             "version": "1.1.3",
@@ -1628,38 +1765,36 @@
             "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
             "devOptional": true
         },
-        "node_modules/@typechain/ethers-v5": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@typechain/ethers-v5/-/ethers-v5-11.1.2.tgz",
-            "integrity": "sha512-ID6pqWkao54EuUQa0P5RgjvfA3MYqxUQKpbGKERbsjBW5Ra7EIXvbMlPp2pcP5IAdUkyMCFYsP2SN5q7mPdLDQ==",
+        "node_modules/@typechain/ethers-v6": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.5.1.tgz",
+            "integrity": "sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "ts-essentials": "^7.0.1"
             },
             "peerDependencies": {
-                "@ethersproject/abi": "^5.0.0",
-                "@ethersproject/providers": "^5.0.0",
-                "ethers": "^5.1.3",
+                "ethers": "6.x",
                 "typechain": "^8.3.2",
-                "typescript": ">=4.3.0"
+                "typescript": ">=4.7.0"
             }
         },
         "node_modules/@typechain/hardhat": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-7.0.0.tgz",
-            "integrity": "sha512-XB79i5ewg9Met7gMVGfgVkmypicbnI25T5clJBEooMoW2161p4zvKFpoS2O+lBppQyMrPIZkdvl2M3LMDayVcA==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-9.1.0.tgz",
+            "integrity": "sha512-mtaUlzLlkqTlfPwB3FORdejqBskSnh+Jl8AIJGjXNAQfRQ4ofHADPl1+oU7Z3pAJzmZbUXII8MhOLQltcHgKnA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "fs-extra": "^9.1.0"
             },
             "peerDependencies": {
-                "@ethersproject/abi": "^5.4.7",
-                "@ethersproject/providers": "^5.4.7",
-                "@typechain/ethers-v5": "^11.0.0",
-                "ethers": "^5.4.7",
+                "@typechain/ethers-v6": "^0.5.1",
+                "ethers": "^6.1.0",
                 "hardhat": "^2.9.9",
-                "typechain": "^8.2.0"
+                "typechain": "^8.3.2"
             }
         },
         "node_modules/@typechain/hardhat/node_modules/fs-extra": {
@@ -2847,50 +2982,88 @@
             }
         },
         "node_modules/ethers": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-            "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+            "version": "6.13.2",
+            "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.2.tgz",
+            "integrity": "sha512-9VkriTTed+/27BGuY1s0hf441kqwHJ1wtN2edksEtiRvXx+soxRX3iSXTfFqq2+YwrOqbDoTHjIhQnjJRlzKmg==",
+            "dev": true,
             "funding": [
                 {
                     "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                    "url": "https://github.com/sponsors/ethers-io/"
                 },
                 {
                     "type": "individual",
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "@ethersproject/abi": "5.7.0",
-                "@ethersproject/abstract-provider": "5.7.0",
-                "@ethersproject/abstract-signer": "5.7.0",
-                "@ethersproject/address": "5.7.0",
-                "@ethersproject/base64": "5.7.0",
-                "@ethersproject/basex": "5.7.0",
-                "@ethersproject/bignumber": "5.7.0",
-                "@ethersproject/bytes": "5.7.0",
-                "@ethersproject/constants": "5.7.0",
-                "@ethersproject/contracts": "5.7.0",
-                "@ethersproject/hash": "5.7.0",
-                "@ethersproject/hdnode": "5.7.0",
-                "@ethersproject/json-wallets": "5.7.0",
-                "@ethersproject/keccak256": "5.7.0",
-                "@ethersproject/logger": "5.7.0",
-                "@ethersproject/networks": "5.7.1",
-                "@ethersproject/pbkdf2": "5.7.0",
-                "@ethersproject/properties": "5.7.0",
-                "@ethersproject/providers": "5.7.2",
-                "@ethersproject/random": "5.7.0",
-                "@ethersproject/rlp": "5.7.0",
-                "@ethersproject/sha2": "5.7.0",
-                "@ethersproject/signing-key": "5.7.0",
-                "@ethersproject/solidity": "5.7.0",
-                "@ethersproject/strings": "5.7.0",
-                "@ethersproject/transactions": "5.7.0",
-                "@ethersproject/units": "5.7.0",
-                "@ethersproject/wallet": "5.7.0",
-                "@ethersproject/web": "5.7.1",
-                "@ethersproject/wordlists": "5.7.0"
+                "@adraffy/ens-normalize": "1.10.1",
+                "@noble/curves": "1.2.0",
+                "@noble/hashes": "1.3.2",
+                "@types/node": "18.15.13",
+                "aes-js": "4.0.0-beta.5",
+                "tslib": "2.4.0",
+                "ws": "8.17.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/ethers/node_modules/@noble/hashes": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+            "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/ethers/node_modules/@types/node": {
+            "version": "18.15.13",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+            "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ethers/node_modules/aes-js": {
+            "version": "4.0.0-beta.5",
+            "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+            "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ethers/node_modules/tslib": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/ethers/node_modules/ws": {
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/ethjs-util": {
@@ -7127,6 +7300,7 @@
             "resolved": "https://registry.npmjs.org/hardhat-contract-sizer/-/hardhat-contract-sizer-2.10.0.tgz",
             "integrity": "sha512-QiinUgBD5MqJZJh1hl1jc9dNnpJg7eE/w4/4GEnrcmZJJTDbVFNe3+/3Ep24XqISSkYxRz36czcPHKHd/a0dwA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "chalk": "^4.0.0",
                 "cli-table3": "^0.6.0",
@@ -7207,10 +7381,11 @@
             }
         },
         "node_modules/hardhat-deploy": {
-            "version": "0.11.45",
-            "resolved": "https://registry.npmjs.org/hardhat-deploy/-/hardhat-deploy-0.11.45.tgz",
-            "integrity": "sha512-aC8UNaq3JcORnEUIwV945iJuvBwi65tjHVDU3v6mOcqik7WAzHVCJ7cwmkkipsHrWysrB5YvGF1q9S1vIph83w==",
+            "version": "0.12.4",
+            "resolved": "https://registry.npmjs.org/hardhat-deploy/-/hardhat-deploy-0.12.4.tgz",
+            "integrity": "sha512-bYO8DIyeGxZWlhnMoCBon9HNZb6ji0jQn7ngP1t5UmGhC8rQYhji7B73qETMOFhzt5ECZPr+U52duj3nubsqdQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@ethersproject/abi": "^5.7.0",
                 "@ethersproject/abstract-signer": "^5.7.0",
@@ -7235,17 +7410,19 @@
                 "match-all": "^1.2.6",
                 "murmur-128": "^0.2.1",
                 "qs": "^6.9.4",
-                "zksync-web3": "^0.14.3"
+                "zksync-ethers": "^5.0.0"
             }
         },
         "node_modules/hardhat-deploy-ethers": {
-            "version": "0.3.0-beta.13",
-            "resolved": "https://registry.npmjs.org/hardhat-deploy-ethers/-/hardhat-deploy-ethers-0.3.0-beta.13.tgz",
-            "integrity": "sha512-PdWVcKB9coqWV1L7JTpfXRCI91Cgwsm7KLmBcwZ8f0COSm1xtABHZTyz3fvF6p42cTnz1VM0QnfDvMFlIRkSNw==",
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/hardhat-deploy-ethers/-/hardhat-deploy-ethers-0.4.2.tgz",
+            "integrity": "sha512-AskNH/XRYYYqPT94MvO5s1yMi+/QvoNjS4oU5VcVqfDU99kgpGETl+uIYHIrSXtH5sy7J6gyVjpRMf4x0tjLSQ==",
             "dev": true,
+            "license": "MIT",
             "peerDependencies": {
-                "ethers": "^5.0.0",
-                "hardhat": "^2.0.0"
+                "@nomicfoundation/hardhat-ethers": "^3.0.2",
+                "hardhat": "^2.16.0",
+                "hardhat-deploy": "^0.12.0"
             }
         },
         "node_modules/hardhat-deploy/node_modules/ansi-styles": {
@@ -7297,6 +7474,55 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
+        "node_modules/hardhat-deploy/node_modules/ethers": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+            "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abi": "5.7.0",
+                "@ethersproject/abstract-provider": "5.7.0",
+                "@ethersproject/abstract-signer": "5.7.0",
+                "@ethersproject/address": "5.7.0",
+                "@ethersproject/base64": "5.7.0",
+                "@ethersproject/basex": "5.7.0",
+                "@ethersproject/bignumber": "5.7.0",
+                "@ethersproject/bytes": "5.7.0",
+                "@ethersproject/constants": "5.7.0",
+                "@ethersproject/contracts": "5.7.0",
+                "@ethersproject/hash": "5.7.0",
+                "@ethersproject/hdnode": "5.7.0",
+                "@ethersproject/json-wallets": "5.7.0",
+                "@ethersproject/keccak256": "5.7.0",
+                "@ethersproject/logger": "5.7.0",
+                "@ethersproject/networks": "5.7.1",
+                "@ethersproject/pbkdf2": "5.7.0",
+                "@ethersproject/properties": "5.7.0",
+                "@ethersproject/providers": "5.7.2",
+                "@ethersproject/random": "5.7.0",
+                "@ethersproject/rlp": "5.7.0",
+                "@ethersproject/sha2": "5.7.0",
+                "@ethersproject/signing-key": "5.7.0",
+                "@ethersproject/solidity": "5.7.0",
+                "@ethersproject/strings": "5.7.0",
+                "@ethersproject/transactions": "5.7.0",
+                "@ethersproject/units": "5.7.0",
+                "@ethersproject/wallet": "5.7.0",
+                "@ethersproject/web": "5.7.1",
+                "@ethersproject/wordlists": "5.7.0"
+            }
+        },
         "node_modules/hardhat-deploy/node_modules/fs-extra": {
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -7330,16 +7556,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/hardhat-deploy/node_modules/zksync-web3": {
-            "version": "0.14.4",
-            "resolved": "https://registry.npmjs.org/zksync-web3/-/zksync-web3-0.14.4.tgz",
-            "integrity": "sha512-kYehMD/S6Uhe1g434UnaMN+sBr9nQm23Ywn0EUP5BfQCsbjcr3ORuS68PosZw8xUTu3pac7G6YMSnNHk+fwzvg==",
-            "deprecated": "This package has been deprecated in favor of zksync-ethers@5.0.0",
-            "dev": true,
-            "peerDependencies": {
-                "ethers": "^5.7.0"
             }
         },
         "node_modules/hardhat-storage-layout-changes": {
@@ -7982,6 +8198,13 @@
             "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
             "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
             "dev": true
+        },
+        "node_modules/lodash.isequal": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lodash.truncate": {
             "version": "4.4.2",
@@ -10026,16 +10249,17 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "version": "5.5.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+            "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
             "devOptional": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
         },
         "node_modules/typical": {
@@ -10334,6 +10558,71 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zksync-ethers": {
+            "version": "5.9.2",
+            "resolved": "https://registry.npmjs.org/zksync-ethers/-/zksync-ethers-5.9.2.tgz",
+            "integrity": "sha512-Y2Mx6ovvxO6UdC2dePLguVzvNToOY8iLWeq5ne+jgGSJxAi/f4He/NF6FNsf6x1aWX0o8dy4Df8RcOQXAkj5qw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ethers": "~5.7.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "ethers": "~5.7.0"
+            }
+        },
+        "node_modules/zksync-ethers/node_modules/ethers": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+            "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abi": "5.7.0",
+                "@ethersproject/abstract-provider": "5.7.0",
+                "@ethersproject/abstract-signer": "5.7.0",
+                "@ethersproject/address": "5.7.0",
+                "@ethersproject/base64": "5.7.0",
+                "@ethersproject/basex": "5.7.0",
+                "@ethersproject/bignumber": "5.7.0",
+                "@ethersproject/bytes": "5.7.0",
+                "@ethersproject/constants": "5.7.0",
+                "@ethersproject/contracts": "5.7.0",
+                "@ethersproject/hash": "5.7.0",
+                "@ethersproject/hdnode": "5.7.0",
+                "@ethersproject/json-wallets": "5.7.0",
+                "@ethersproject/keccak256": "5.7.0",
+                "@ethersproject/logger": "5.7.0",
+                "@ethersproject/networks": "5.7.1",
+                "@ethersproject/pbkdf2": "5.7.0",
+                "@ethersproject/properties": "5.7.0",
+                "@ethersproject/providers": "5.7.2",
+                "@ethersproject/random": "5.7.0",
+                "@ethersproject/rlp": "5.7.0",
+                "@ethersproject/sha2": "5.7.0",
+                "@ethersproject/signing-key": "5.7.0",
+                "@ethersproject/solidity": "5.7.0",
+                "@ethersproject/strings": "5.7.0",
+                "@ethersproject/transactions": "5.7.0",
+                "@ethersproject/units": "5.7.0",
+                "@ethersproject/wallet": "5.7.0",
+                "@ethersproject/web": "5.7.1",
+                "@ethersproject/wordlists": "5.7.0"
             }
         }
     }

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -7,14 +7,25 @@
         "lib": "lib",
         "test": "test"
     },
+    "main": "typechain/index.js",
+    "types": "typechain/index.d.ts",
+    "exports": {
+        "./typechain": "./typechain",
+        "./contracts/": "./contracts/src/",
+        "./sdk/": "./sdk/"
+    },
     "files": [
         "contracts",
         "sdk",
+        "typechain/**/*.js?(.map)",
+        "typechain/**/*.ts",
+        "hardhat.config.*",
         "README.md",
         "LICENSE-APACHE",
         "LICENSE-MIT"
     ],
     "scripts": {
+        "build": "npx hardhat compile && npx tsc -p ./tsconfig.build.json",
         "prepack": "node scripts/npm-prepack.js",
         "postpack": "node scripts/npm-postpack.js",
         "test": "echo \"Error: no test specified\" && exit 1"
@@ -32,19 +43,19 @@
     },
     "homepage": "https://github.com/consensus-shipyard/ipc/",
     "devDependencies": {
-        "@nomicfoundation/hardhat-foundry": "^1.0.1",
-        "@nomiclabs/hardhat-ethers": "^2.2.3",
-        "@openzeppelin/contracts": "5.0.1",
-        "@typechain/ethers-v5": "^11.1.2",
-        "@typechain/hardhat": "^7.0.0",
+        "@nomicfoundation/hardhat-ethers": "^3.0.6",
+        "@nomicfoundation/hardhat-foundry": "^1.1.2",
+        "@openzeppelin/contracts": "^5.0.1",
+        "@typechain/ethers-v6": "^0.5.1",
+        "@typechain/hardhat": "^9.1.0",
         "dotenv": "^16.0.1",
         "elliptic-curve-solidity": "github:witnet/elliptic-curve-solidity#3475478",
-        "ethers": "^5.7.0",
+        "ethers": "^6.13.2",
         "fevmate": "github:wadealexc/fevmate#6a80e98",
         "fs-extra": "^11.2.0",
-        "hardhat-contract-sizer": "^2.6.1",
-        "hardhat-deploy": "^0.11.14",
-        "hardhat-deploy-ethers": "^0.3.0-beta.13",
+        "hardhat-contract-sizer": "^2.10.0",
+        "hardhat-deploy": "^0.12.4",
+        "hardhat-deploy-ethers": "^0.4.2",
         "husky": "^8.0.3",
         "lint-staged": "^15.0.2",
         "prettier": "^2.8.8",
@@ -53,7 +64,7 @@
         "solhint-plugin-prettier": "^0.0.5",
         "ts-node": "^10.9.1",
         "typechain": "^8.3.2",
-        "typescript": "^4.8.3"
+        "typescript": "^5.5.4"
     },
     "dependencies": {
         "@solidity-parser/parser": "^0.16.2",

--- a/contracts/tsconfig.build.json
+++ b/contracts/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": null,
+        "declaration": true,
+        "sourceMap": true,
+        "declarationMap": true,
+        "skipLibCheck": true
+    },
+    "include": ["./typechain/**/*"],
+    "files": ["hardhat.config.ts"]
+}

--- a/contracts/tsconfig.json
+++ b/contracts/tsconfig.json
@@ -1,1 +1,14 @@
-{}
+{
+    "compilerOptions": {
+        "target": "es2018",
+        "lib": ["es2021"],
+        "module": "commonjs",
+        "strict": false,
+        "esModuleInterop": true,
+        "moduleResolution": "node",
+        "outDir": "dist",
+        "declaration": true
+    },
+    "include": ["./typechain"],
+    "files": ["./hardhat.config.ts"]
+}


### PR DESCRIPTION
## Summary

- The JS SDK uses ethers v6, so we update it and make change accordingly
- The JS SDK also needs to import typechain types, so we make them available

## Details

In a JS repo, I can now import and use IPC contracts (via a symlink to this repo/dir):
```
import { GatewayGetterFacet__factory } from "@consensus-shipyard/ipc-contracts";
```