### PR TITLE
Retire tokens

### DIFF
--- a/fendermint/actors/blobs/src/actor.rs
+++ b/fendermint/actors/blobs/src/actor.rs
@@ -74,7 +74,7 @@ impl BlobsActor {
     fn distribute_tokens(rt: &impl Runtime) -> Result<(), ActorError> {
         let current_balance = rt.current_balance();
         let caller = rt.message().origin();
-        let amount_to_retire = current_balance.clone().div_floor(100).mul(97);
+        let amount_to_retire = current_balance.clone().div_floor(100).mul(50);
         let amount_for_caller = current_balance.min(amount_to_retire.clone());
         extract_send_result(rt.send_simple(
             &BURNT_FUNDS_ACTOR_ADDR,


### PR DESCRIPTION
Once in a while we should retire tokens. That means a message to blobs actor, so that it could send the tokens to the ~~destination~~ no-return address. I made an attempt to do all the piping, but we have already a debit mechanism.

Once in a while, the system calls the blobs actor to debit users credits account. So, scrap the first attempt, IMO, it makes sense to piggy back on the existing debit mechanism.

At a predefined period, the actor sends 97% of the tokens to *burnt funds actor*, while the remaining 3% gets delivered to the one who initiated the debit action. Seems fair.

As validators rotate, from a validators perspective this looks like probabilistic payments.

One might set the ration (retired vs to the validator) at the genesis, but before that (breaking yet sort of trivial) change, I would like to ask a reviewer:
1. How do you find if tokens retirement piggybacks on debit-credit mechanism?
2. Is 97% vs 3% okay?
3. Silly Q: I assume that the validators who call debit-credit mechanism rotate. Is this right?
4. Even more silly Q: `message.origin` refers to the validator address, right?
5. Should the percentage be in the genesis?