### PR TITLE
fix(scripts): set `FM_LOG_DOMAINS` if not provided

### DIFF
--- a/scripts/deploy_subnet/deploy.sh
+++ b/scripts/deploy_subnet/deploy.sh
@@ -49,11 +49,15 @@ IPC_CONFIG_FOLDER=${HOME}/.ipc
 if [[ -z "${FM_LOG_LEVEL:-}" ]]; then
   FM_LOG_LEVEL="info"
 fi
+if [[ -z "${FM_LOG_DOMAINS:-}" ]]; then
+  FM_LOG_DOMAINS=Bottomup,Consensus,Execution,Mpool,System,Topdown
+fi
 
 echo "$DASHES starting with env $DASHES"
 echo "IPC_FOLDER $IPC_FOLDER"
 echo "IPC_CONFIG_FOLDER $IPC_CONFIG_FOLDER"
 echo "FM_LOG_LEVEL $FM_LOG_LEVEL"
+echo "FM_LOG_DOMAINS $FM_LOG_DOMAINS"
 
 wallet_addresses=()
 public_keys=()


### PR DESCRIPTION
Fixes localnet script wherein the `FM_LOG_DOMAINS` is not set, causing an error: `./scripts/deploy_subnet/deploy.sh: line 537: FM_LOG_DOMAINS: unbound variable`. i.e., we should assume a `env` file is not provided / sourced.