### PR TITLE
fix: clean.sh file execution permission

### DIFF
--- a/fendermint/testing/contract-test/tests/run_upgrades.rs
+++ b/fendermint/testing/contract-test/tests/run_upgrades.rs
@@ -86,11 +86,6 @@ async fn test_applying_upgrades() {
 
                 // execute the message
                 let (res, _) = state.execute_implicit(message).unwrap();
-
-println!("");
-println!("res {:?}", res);
-println!("");
-
                 assert!(
                     res.msg_receipt.exit_code.is_success(),
                     "{:?}",


### PR DESCRIPTION
The `./scripts/clean.sh` file was set to 644, which prevents one from running the script regularly.  This PR switches to 755.