### PR TITLE
chore: make it clearer if "free" means "available" or "total" in the blobs actor

### DIFF
--- a/fendermint/actors/blobs/src/state.rs
+++ b/fendermint/actors/blobs/src/state.rs
@@ -384,6 +384,7 @@ impl State {
             // New blob increases network capacity as well.
             // Ensure there is enough capacity available.
             let available_capacity = &self.capacity_total - &self.capacity_used;
+
             if size > available_capacity {
                 return Err(ActorError::forbidden(format!(
                     "subnet has insufficient storage capacity (available: {}; required: {})",


### PR DESCRIPTION
There are two fields: `capacity_free` and `capacity_used`. The name implies `capacity_free` is available capacity, as opposed to "used" one. It seems though, `capacity_free` implies total capacity. So, renamed `capacity_free` to `capacity_total`.