### PR TITLE
feat: required CID for accumulator witness data

### DIFF
--- a/fendermint/actors/timehub/src/actor.rs
+++ b/fendermint/actors/timehub/src/actor.rs
@@ -9,28 +9,52 @@ use fil_actors_runtime::{
     runtime::{ActorCode, Runtime},
     ActorError,
 };
+use tracing::debug;
 
-use crate::{Method, PushParams, PushReturn, State, TIMEHUB_ACTOR_NAME};
+use crate::{Leaf, Method, PushParams, PushReturn, State, TIMEHUB_ACTOR_NAME};
 
 #[cfg(feature = "fil-actor")]
 fil_actors_runtime::wasm_trampoline!(Actor);
 
 pub struct Actor;
 
+// Raw type persisted in the store.
+// This avoids using CID so that the store does not try to validate or resolve it.
+type RawLeaf = (u64, Vec<u8>);
+
 impl Actor {
     fn push(rt: &impl Runtime, params: PushParams) -> Result<PushReturn, ActorError> {
         Self::ensure_write_allowed(rt)?;
 
+        // Decode the raw bytes as a Cid and report any errors.
+        // However we pass opaque bytes to the store as it tries to validate and resolve any CIDs
+        // it stores.
+        let _cid = Cid::try_from(params.0.as_slice()).map_err(|_err| {
+            actor_error!(illegal_argument;
+                    "data must be valid CID bytes")
+        })?;
         let timestamp = rt.tipset_timestamp();
-        let data = (timestamp, params.0);
+        let data: RawLeaf = (timestamp, params.0);
 
         rt.transaction(|st: &mut State, rt| st.push(rt.store(), data))
     }
 
-    fn get_leaf_at(rt: &impl Runtime, index: u64) -> Result<Option<(u64, Vec<u8>)>, ActorError> {
+    fn get_leaf_at(rt: &impl Runtime, index: u64) -> Result<Option<Leaf>, ActorError> {
+        debug!(index, "get_leaf_at");
         rt.validate_immediate_caller_accept_any()?;
         let st: State = rt.state()?;
-        st.get_leaf_at(rt.store(), index)
+        // Decode leaf as timestamp and raw bytes. Then decode as a CID
+        let leaf: Option<RawLeaf> = st.get_leaf_at(rt.store(), index)?;
+        Ok(leaf
+            .map(|(timestamp, bytes)| -> Result<Leaf, ActorError> {
+                Ok(Leaf {
+                    timestamp,
+                    witnessed: Cid::try_from(bytes).map_err(
+                        |_err| actor_error!(illegal_argument; "internal bytes are not a valid CID"),
+                    )?,
+                })
+            })
+            .transpose()?)
     }
 
     fn get_root(rt: &impl Runtime) -> Result<Cid, ActorError> {

--- a/fendermint/actors/timehub/src/shared.rs
+++ b/fendermint/actors/timehub/src/shared.rs
@@ -55,6 +55,14 @@ pub struct PushReturn {
     pub index: u64,
 }
 
+#[derive(Debug, Serialize_tuple, Deserialize_tuple)]
+pub struct Leaf {
+    /// Timestamp of the witness in seconds since the UNIX epoch
+    pub timestamp: u64,
+    /// Witnessed CID
+    pub witnessed: Cid,
+}
+
 /// Compute the hash of a pair of CIDs.
 /// The hash is the CID of a new block containing the concatenation of the two CIDs.
 /// We do not include the index of the element(s) because incoming data should already be "nonced".
@@ -192,8 +200,8 @@ fn get_at<BS: Blockstore, S: DeserializeOwned + Serialize>(
     peaks: &Amt<Cid, &BS>,
 ) -> anyhow::Result<Option<S>> {
     let (path, eigen_index) = match path_for_eigen_root(leaf_index, leaf_count)? {
-        None => {return Ok(None)}
-        Some(res) => {res}
+        None => return Ok(None),
+        Some(res) => res,
     };
     let cid = match peaks.get(eigen_index)? {
         Some(cid) => cid,


### PR DESCRIPTION
This change validates that the accumulator data payload is a valid CID. Additionally creates a Leaf type that is the return of the Get rpc call instead of a vanilla tuple, (we still use a tuple over the wire).

I have a change pending against the SDK for these changes as well.

Fixes HES-383