### PR TITLE
chore: treat spaces in PATH env gently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ lint: license $(patsubst %, lint/%, $(SUBTREES_ALL))
 ## Hoku
 
 config-devnet:
-	PATH=$(PATH):./target/release \
+	PATH="$(PATH):./target/release" \
 	./scripts/setup.sh
 
 run-devnet-iroh:


### PR DESCRIPTION
Makefile fails if PATH env contains spaces. Now it does not.