### PR TITLE
fix: failing unit and e2e tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,18 +19,6 @@ jobs:
             ${{ secrets.BUILTIN_ACTORS_DEPLOY_KEY }}
             ${{ secrets.CONTRACTS_DEPLOY_KEY }}
 
-      # https://github.com/marketplace/actions/free-disk-space-ubuntu
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          large-packages: false
-          swap-storage: false
-          docker-images: false
-          android: true
-          dotnet: true
-          haskell: true
-
       - name: Check out the project
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests-e2e.yaml
+++ b/.github/workflows/tests-e2e.yaml
@@ -56,4 +56,3 @@ jobs:
 
       - name: Run e2e tests
         run: cd fendermint && PROFILE=release make e2e-only
-

--- a/.github/workflows/tests-unit.yaml
+++ b/.github/workflows/tests-unit.yaml
@@ -45,4 +45,3 @@ jobs:
 
       - name: Run unit tests
         run: make test-rust
-

--- a/fendermint/Makefile
+++ b/fendermint/Makefile
@@ -50,7 +50,7 @@ e2e: docker-build | cargo-make
 	${MAKE} e2e-only
 
 e2e-only:
-	cd testing/smoke-test    && cargo make --profile $(PROFILE)
+	cd testing/smoke-test && cargo make --profile $(PROFILE)
 
 clean:
 	cargo clean

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.81.0"
 components = ["clippy", "llvm-tools", "rustfmt"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
A new version of rust causes reference-types to be disabled by default in `wasmtime`. the normal fix is to enable the `gc` feature, but the version of `wasmtime` used in the version of `ref-fvm` is quite old and doesn't have this feature... somehow it relies on rust to determine whether or not reference-types are enabled by default. 

See https://github.com/bytecodealliance/wasmtime/issues/9130
See https://github.com/bytecodealliance/wasmtime/pull/9162

For now, I'm just going to lock the roolchain to rust `1.81.0`. I'll create an issue upstream to see where we're at in terms of updating the `ref-fvm` dependency. Looks like the team there is about to update to wasmtime v25: https://github.com/filecoin-project/ref-fvm/pull/2059, which will fix this issue. 

Closes #281 