### PR TITLE
feat: Docker contract deployment for artifacts

### DIFF
--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:latest
+
+RUN apt-get update && apt-get install -y \
+    build-essential libssl-dev mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config curl clang hwloc libhwloc-dev wget ca-certificates gnupg
+
+COPY . /ipc
+WORKDIR /ipc
+# Install rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+# Install forge
+RUN curl -L https://foundry.paradigm.xyz | bash
+RUN . /root/.bashrc && foundryup
+# Install nvm
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+# Set nvm to use system node
+ENV NVM_DIR=/root/.nvm
+RUN . $NVM_DIR/nvm.sh && nvm install 20
+
+# build contracts
+# RUN . /root/.bashrc && cd contracts && forge install && forge build && npm install hardhat

--- a/infra/contract-deployments.md
+++ b/infra/contract-deployments.md
@@ -1,0 +1,43 @@
+# Contract Deployments
+
+Contract deployment involves a lot of setup and inputs as well as generating a lot of artifacts.
+
+This document captures the steps to get the addresses of the deployed contracts, version of code and tools used for deployment in a docker container.
+
+
+
+## Filecoin Calibration Testnet
+
+### Ignition
+
+docker_image=3boxben/ipc:ignition-contracts
+
+List ipc contracts out artifacts:
+```
+docker run --rm  ${docker_image} ls -l ./contracts/out
+```
+
+Get the PARENT_GATEWAY_ADDRESS:
+```
+docker run --rm  ${docker_image} jq -r .address contracts/deployments/calibrationnet/GatewayDiamond.json
+```
+
+Get the PARENT_REGISTRY_ADDRESS:
+```
+docker run --rm  ${docker_image} jq -r .address contracts/deployments/calibrationnet/SubnetRegistryDiamond.json
+```
+
+Get the SUPPLY_SOURCE_ADDRESS:
+```
+docker run --rm  ${docker_image} jq -r '.transactions | .[] | select(.contractName == "ERC1967Proxy") | .contractAddress' ./hoku-contracts/broadcast/Hoku.s.sol/314159/run-latest.json
+```
+
+Get the VALIDATOR_GATER_ADDRESS:
+```
+docker run --rm  ${docker_image} jq -r '.transactions | .[] | select(.contractName == "ValidatorGater") | .contractAddress'  ./hoku-contracts/broadcast/ValidatorGater.s.sol/314159/run-latest.json
+```
+
+PARENT_GATEWAY_ADDRESS=0xaDfc2428D57c58c322CFFa7307b7e63402accd17
+PARENT_REGISTRY_ADDRESS=0xDe4C2e132011CC3279484dFD1d2557c84517277a
+SUPPLY_SOURCE_ADDRESS=0x9e947917d1812c2ab813704315f739f1d9f858a9
+VALIDATOR_GATER_ADDRESS=0x907fa3b65907563d71eb9a7b4ac9321aaf53b67e


### PR DESCRIPTION
In an effort to preserve contract deployments, and they deployment environments, I added a Dockerfile.

Once deployment is complete, the resulting image can be committed to an image repository.

This provides reference for the source of deployed artifacts and a means to reproduce them.

TODO:

- [ ] the image is MASSIVE (6+GB)
- [ ] script the deployment in the Dockerfile

Question: Does this image contain sensitive values used for deployment?