### PR TITLE
fix: localnet script `sed` usage

### DIFF
--- a/scripts/deploy_subnet/deploy.sh
+++ b/scripts/deploy_subnet/deploy.sh
@@ -528,8 +528,8 @@ echo "$create_subnet_output"
 echo
 
 subnet_id=$(echo "$create_subnet_output" | sed -n 's/.*with id: *\([^ ]*\).*/\1/p')
-subnet_root=$(echo "$subnet_id" | sed 's|/[^0-9]*\([0-9]\+\)/.*|\1|')
-subnet_f4_addr=$(echo "$subnet_id" | sed 's|.*/||')
+subnet_root=$(echo "$subnet_id" | awk -F'[/]' '{print $2}' | sed 's/[^0-9]//g')
+subnet_f4_addr=${subnet_id##*/}
 subnet_eth_addr=$(ipc-cli util f4-to-eth-addr --addr "$subnet_f4_addr" | sed -n 's/.*\(0x[0-9a-fA-F]\{40\}\).*/\1/p')
 echo "Created new subnet id: $subnet_id ($subnet_eth_addr)"
 


### PR DESCRIPTION
- Uses a different `awk` + `sed` pattern wrt `subnet_root` so things work on macos. (It currently doesn't extract anything and grabs the whole `/r31337/t410fkzrz3mlkyufisiuae3scumllgalzuu3wxlxa2ly` instead of `31337`, so localnet fails to start.)
- Fixes shellcheck warning `SC2001 (style): See if you can use ${variable//search/replace}` wrt `subnet_f4_addr`.

Note: we might wanna check these work the same on ubuntu, but I _think_ they do.