### PR TITLE
ci: add cargo net fetch with cli env

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,10 @@ name: Build IPC
 on:
   workflow_call:
 
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+
 jobs:
   build:
     name: Build IPC

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -6,6 +6,8 @@ on:
 
 env:
   PROFILE: "ci"
+  CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
 
 jobs:
 

--- a/.github/workflows/tests-e2e.yaml
+++ b/.github/workflows/tests-e2e.yaml
@@ -4,6 +4,10 @@ name: Run e2e tests
 on:
   workflow_call:
 
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+
 jobs:
   run:
     runs-on: self-hosted

--- a/.github/workflows/tests-unit.yaml
+++ b/.github/workflows/tests-unit.yaml
@@ -4,6 +4,10 @@ name: Run unit tests
 on:
   workflow_call:
 
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+
 jobs:
   run:
     runs-on: self-hosted


### PR DESCRIPTION
I _think_ `CARGO_NET_GIT_FETCH_WITH_CLI: true` is needed now because `entanglement` is imported as a cargo dep, not submodule, like in `rust-hoku` where it's required. 