### PR TITLE
fix: failing docker builds trying to fetch private git repos in Dockerfile

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -34,6 +34,11 @@ jobs:
           submodules: recursive
           ssh-key: ${{ secrets.IPC_DEPLOY_KEY }}
 
+      - name: Collect Git and SSH config files in a directory that is part of the Docker build context
+        run: |
+          mkdir root-config
+          cp -r ~/.gitconfig ~/.ssh root-config/
+
       - name: Install Tools
         uses: ./.github/actions/install-tools
         with:

--- a/fendermint/docker/builder.ci.Dockerfile
+++ b/fendermint/docker/builder.ci.Dockerfile
@@ -35,7 +35,7 @@ FROM --platform=$BUILDPLATFORM ubuntu:jammy as builder
 
 RUN apt-get update && \
   apt-get install -y build-essential clang cmake protobuf-compiler curl \
-  openssl libssl-dev pkg-config
+  openssl libssl-dev pkg-config git-core
 
 # Get Rust
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
@@ -67,6 +67,10 @@ RUN if [ "${TARGETARCH}" = "arm64" ]; then \
 
 # Copy the stripped source code.
 COPY --from=stripper /app /app
+
+COPY root-config /root/
+RUN sed 's|/home/ghrunner|/root|g' -i.bak /root/.ssh/config
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 # Build the dependencies.
 RUN \


### PR DESCRIPTION
* Copy ssh and git config into `Dockerfile` to correctly fetch private repos inside the `Dockerfile`.
* Here is a successful build (the image was not pushed): https://github.com/hokunet/ipc/actions/runs/11662818602/job/32469942281
* See the analyses in the issue #309 

closes #309 