### PR TITLE
chore: bump entangler version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2511,7 +2511,7 @@ dependencies = [
 [[package]]
 name = "entangler"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/entanglement.git?rev=8113eed819e4a2eac4988b842a8806174ed486b0#8113eed819e4a2eac4988b842a8806174ed486b0"
+source = "git+ssh://git@github.com/hokunet/entanglement.git?rev=dc93353e97a438a800a4a22ed46fe75e77eca200#dc93353e97a438a800a4a22ed46fe75e77eca200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10984,7 +10984,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/entanglement.git?rev=8113eed819e4a2eac4988b842a8806174ed486b0#8113eed819e4a2eac4988b842a8806174ed486b0"
+source = "git+ssh://git@github.com/hokunet/entanglement.git?rev=dc93353e97a438a800a4a22ed46fe75e77eca200#dc93353e97a438a800a4a22ed46fe75e77eca200"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,8 +80,8 @@ data-encoding = { version = "2.3.3" }
 dirs = "5.0"
 dircpy = "0.3.19"
 either = "1.10"
-entangler = { git = "ssh://git@github.com/hokunet/entanglement.git", rev = "8113eed819e4a2eac4988b842a8806174ed486b0" }
-entangler_storage = { package = "storage", git = "ssh://git@github.com/hokunet/entanglement.git", rev = "8113eed819e4a2eac4988b842a8806174ed486b0" }
+entangler = { git = "ssh://git@github.com/hokunet/entanglement.git", rev = "dc93353e97a438a800a4a22ed46fe75e77eca200" }
+entangler_storage = { package = "storage", git = "ssh://git@github.com/hokunet/entanglement.git", rev = "dc93353e97a438a800a4a22ed46fe75e77eca200" }
 env_logger = "0.10"
 erased-serde = "0.3"
 ethers = { version = "2.0.13", features = ["abigen", "ws"] }


### PR DESCRIPTION
Switch to entangler with a fix for uploading large (>10Mb) blobs.