### PR TITLE
WIP Use RAII to ensure hamt is always updated

### DIFF
--- a/fendermint/actors/blobs/src/accounts.rs
+++ b/fendermint/actors/blobs/src/accounts.rs
@@ -96,15 +96,18 @@ where
     }
 
     pub fn get_or_create(
-        &self,
-        addr: &Address,
+        self,
+        addr: &Address, // todo take by value
         current_epoch: ChainEpoch,
-    ) -> Result<Account, ActorError> {
-        if let Some(a) = self.map.get(addr)? {
+        accounts_root: &mut Cid,
+    ) -> Result<AccountHolder<'a, BS>, ActorError> {
+        let account: Account = if let Some(a) = self.map.get(addr)? {
             Ok(a.clone())
         } else {
             Ok(Account::new(current_epoch))
-        }
+        }?;
+
+        Ok(AccountHolder::new(account, addr.clone(), self, accounts_root))
     }
 
     pub fn set_and_flush(&mut self, addr: &Address, account: Account) -> Result<Cid, ActorError> {


### PR DESCRIPTION
Here's a very rough POC of what I was thinking about in this comment: https://github.com/hokunet/ipc/pull/379#discussion_r1876438801

This doesn't actually compile or work currently, and I'm not sure how much work it would be to make it actually usable.  Perhaps @nathanielc or @dav1do have some ideas on how to better structure this or an alternative approach that would work better.

But anytime I see code that creates a pattern where any time a dev does thing A they need to remember to also do thing B, but doing thing B isn't enforced by the compiler, that sets off a warning alarm to me.  That is a very common pitfall that leads to bugs slipping in.