### PR TITLE
feat: adds support to modifying object's metadata

### DIFF
--- a/fendermint/actors/bucket/src/shared.rs
+++ b/fendermint/actors/bucket/src/shared.rs
@@ -16,7 +16,9 @@ use serde::{Deserialize, Serialize};
 pub use crate::state::{ObjectState, State};
 
 pub const BUCKET_ACTOR_NAME: &str = "bucket";
-
+pub const MAX_METADATA_ENTRIES: u32 = 20;
+pub const MAX_METADATA_KEY_SIZE: u32 = 32;
+pub const MAX_METADATA_VALUE_SIZE: u32 = 128;
 #[derive(FromPrimitive)]
 #[repr(u64)]
 pub enum Method {
@@ -28,7 +30,7 @@ pub enum Method {
     DeleteObject = frc42_dispatch::method_hash!("DeleteObject"),
     GetObject = frc42_dispatch::method_hash!("GetObject"),
     ListObjects = frc42_dispatch::method_hash!("ListObjects"),
-    ModifyObjectMetadata = frc42_dispatch::method_hash!("ModifyObjectMetadata"),
+    UpdateObjectMetadata = frc42_dispatch::method_hash!("UpdateObjectMetadata"),
 }
 
 /// Params for adding an object.
@@ -107,7 +109,7 @@ pub struct ListObjectsReturn {
 }
 
 #[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple)]
-pub struct ModifyObjectMetadataParams {
+pub struct UpdateObjectMetadataParams {
     /// Object key.
     #[serde(with = "strict_bytes")]
     pub key: Vec<u8>,


### PR DESCRIPTION
# Summary

Currently, we cannot update/delete metadata from existing object. Adds support to modifying object's metadata

Closes #373 