### PR TITLE
chore: use config actor in blobs actor

### DIFF
--- a/fendermint/actors/blobs/shared/src/params.rs
+++ b/fendermint/actors/blobs/shared/src/params.rs
@@ -214,9 +214,9 @@ pub struct GetStatsReturn {
     /// The current token balance earned by the subnet.
     pub balance: TokenAmount,
     /// The total free storage capacity of the subnet.
-    pub capacity_free: BigInt,
+    pub capacity_free: u64,
     /// The total used storage capacity of the subnet.
-    pub capacity_used: BigInt,
+    pub capacity_used: u64,
     /// The total number of credits sold in the subnet.
     pub credit_sold: BigInt,
     /// The total number of credits committed to active storage in the subnet.

--- a/fendermint/actors/blobs/shared/src/state.rs
+++ b/fendermint/actors/blobs/shared/src/state.rs
@@ -16,7 +16,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, PartialEq, Serialize_tuple, Deserialize_tuple)]
 pub struct Account {
     /// Total size of all blobs managed by the account.
-    pub capacity_used: BigInt,
+    pub capacity_used: u64,
     /// Current free credit in byte-blocks that can be used for new commitments.
     pub credit_free: BigInt,
     /// Current committed credit in byte-blocks that will be used for debits.

--- a/fendermint/actors/blobs/src/shared.rs
+++ b/fendermint/actors/blobs/src/shared.rs
@@ -2,18 +2,6 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_ipld_encoding::tuple::*;
-
 pub use crate::state::State;
 
 pub const BLOBS_ACTOR_NAME: &str = "blobs";
-
-/// Params for actor construction.
-/// TODO: Remove constructor params
-#[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple)]
-pub struct ConstructorParams {
-    /// The total storage capacity of the subnet.
-    pub blob_capacity: u64,
-    /// The byte-blocks per atto token rate.
-    pub blob_credits_per_byte_block: u64,
-}

--- a/fendermint/actors/hoku_config/shared/src/lib.rs
+++ b/fendermint/actors/hoku_config/shared/src/lib.rs
@@ -7,9 +7,11 @@ use fil_actors_runtime::{deserialize_block, extract_send_result, ActorError};
 use fvm_ipld_encoding::tuple::*;
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
+use fvm_shared::econ::TokenAmount;
 use fvm_shared::sys::SendFlags;
 use fvm_shared::{ActorID, MethodNum, METHOD_CONSTRUCTOR};
 use num_derive::FromPrimitive;
+use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
 pub const HOKU_CONFIG_ACTOR_ID: ActorID = 70;
@@ -57,7 +59,7 @@ pub fn get_admin(rt: &impl Runtime) -> Result<Option<Address>, ActorError> {
         &HOKU_CONFIG_ACTOR_ADDR,
         Method::GetAdmin as MethodNum,
         None,
-        rt.message().value_received(),
+        TokenAmount::zero(),
         None,
         SendFlags::READ_ONLY,
     ))?)
@@ -68,7 +70,7 @@ pub fn get_config(rt: &impl Runtime) -> Result<HokuConfig, ActorError> {
         &HOKU_CONFIG_ACTOR_ADDR,
         Method::GetConfig as MethodNum,
         None,
-        rt.message().value_received(),
+        TokenAmount::zero(),
         None,
         SendFlags::READ_ONLY,
     ))?)

--- a/fendermint/vm/interpreter/src/genesis.rs
+++ b/fendermint/vm/interpreter/src/genesis.rs
@@ -442,12 +442,7 @@ impl GenesisBuilder {
             .context("failed to create hoku config actor")?;
 
         // Initialize the blob actor.
-        // TODO: Remove constructor params that live in the hoku config actor
-        let blobs_state = fendermint_actor_blobs::State::new(
-            &state.store(),
-            hoku_config_state.config.blob_capacity,
-            hoku_config_state.config.blob_credits_per_byte_block,
-        )?;
+        let blobs_state = fendermint_actor_blobs::State::new(&state.store())?;
         state
             .create_custom_actor(
                 fendermint_actor_blobs::BLOBS_ACTOR_NAME,


### PR DESCRIPTION
@sanderpick I am surprised an actor is expected to send tokens to the config actor while getting current config and getting config actor admin:
- https://github.com/hokunet/ipc/pull/408/files#diff-2ac9707b3f050061795fe1a94722dfbfd72e541df6267c7f50fa715bfa669a07R62
- https://github.com/hokunet/ipc/pull/408/files#diff-2ac9707b3f050061795fe1a94722dfbfd72e541df6267c7f50fa715bfa669a07R74

<s>Commented the lines so that the tokens are not sent. Please, let me know what is a desired behavior wrt the tokens.</s>

No tokens get sent to the config actor.

Should fix https://github.com/hokunet/ipc/issues/383