### PR TITLE
refactor: changes credit representation to be multiple of attos

### DIFF
--- a/fendermint/actors/blobs/shared/src/lib.rs
+++ b/fendermint/actors/blobs/shared/src/lib.rs
@@ -8,14 +8,13 @@ use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::{deserialize_block, extract_send_result, ActorError};
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::address::Address;
-use fvm_shared::bigint::BigUint;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::sys::SendFlags;
 use fvm_shared::{ActorID, MethodNum, METHOD_CONSTRUCTOR};
 use num_derive::FromPrimitive;
 
-use crate::state::{Account, CreditApproval, Subscription};
+use crate::state::{Account, Credit, CreditApproval, Subscription};
 
 pub mod params;
 pub mod state;
@@ -63,7 +62,7 @@ pub fn approve_credit(
     from: Address,
     to: Address,
     caller_allowlist: Option<HashSet<Address>>,
-    credit_limit: Option<BigUint>,
+    credit_limit: Option<Credit>,
     gas_fee_limit: Option<TokenAmount>,
     ttl: Option<ChainEpoch>,
 ) -> Result<CreditApproval, ActorError> {

--- a/fendermint/actors/blobs/shared/src/params.rs
+++ b/fendermint/actors/blobs/shared/src/params.rs
@@ -4,13 +4,13 @@
 
 use fvm_ipld_encoding::tuple::*;
 use fvm_shared::address::Address;
-use fvm_shared::bigint::{BigInt, BigUint};
+use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
-use crate::state::{BlobStatus, Hash, PublicKey, SubscriptionId, TtlStatus};
+use crate::state::{BlobStatus, Credit, Hash, PublicKey, SubscriptionId, TtlStatus};
 
 /// Params for buying credits.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -42,7 +42,7 @@ pub struct ApproveCreditParams {
     /// Optional credit approval limit.
     /// If specified, the approval becomes invalid once the committed credits reach the
     /// specified limit.
-    pub credit_limit: Option<BigUint>,
+    pub credit_limit: Option<Credit>,
     /// Optional gas fee limit.
     /// If specified, the approval becomes invalid once the commited gas reach the
     /// specified limit.
@@ -210,13 +210,13 @@ pub struct GetStatsReturn {
     /// The total used storage capacity of the subnet.
     pub capacity_used: BigInt,
     /// The total number of credits sold in the subnet.
-    pub credit_sold: BigInt,
+    pub credit_sold: Credit,
     /// The total number of credits committed to active storage in the subnet.
-    pub credit_committed: BigInt,
+    pub credit_committed: Credit,
     /// The total number of credits debited in the subnet.
-    pub credit_debited: BigInt,
-    /// The token to credit rate. The amount of credits that 1 atto buys.
-    pub token_credit_rate: u64,
+    pub credit_debited: Credit,
+    /// The token to credit rate. The amount of atto credits that 1 atto buys.
+    pub token_credit_rate: BigInt,
     /// Total number of debit accounts.
     pub num_accounts: u64,
     /// Total number of actively stored blobs.

--- a/fendermint/actors/blobs/shared/src/state.rs
+++ b/fendermint/actors/blobs/shared/src/state.rs
@@ -14,15 +14,19 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::str::FromStr;
 
+/// Credit is counted the same way as tokens.
+/// The smallest indivisible unit is 1 atto, and 1 credit = 1e18 atto credits.
+pub type Credit = TokenAmount;
+
 /// The stored representation of a credit account.
 #[derive(Clone, Debug, Default, PartialEq, Serialize_tuple, Deserialize_tuple)]
 pub struct Account {
     /// Total size of all blobs managed by the account.
     pub capacity_used: BigInt,
     /// Current free credit in byte-blocks that can be used for new commitments.
-    pub credit_free: BigInt,
+    pub credit_free: Credit,
     /// Current committed credit in byte-blocks that will be used for debits.
-    pub credit_committed: BigInt,
+    pub credit_committed: Credit,
     /// Optional default sponsor account address.
     pub credit_sponsor: Option<Address>,
     /// The chain epoch of the last debit.
@@ -55,13 +59,13 @@ impl Account {
 #[derive(Debug, Clone, PartialEq, Serialize_tuple, Deserialize_tuple)]
 pub struct CreditApproval {
     /// Optional credit approval limit.
-    pub credit_limit: Option<BigInt>,
+    pub credit_limit: Option<Credit>,
     /// Used to limit gas fee delegation.
     pub gas_fee_limit: Option<TokenAmount>,
     /// Optional credit approval expiry epoch.
     pub expiry: Option<ChainEpoch>,
     /// Counter for how much credit has been used via this approval.
-    pub credit_used: BigInt,
+    pub credit_used: Credit,
     /// Used to track gas fees paid for by the delegation
     pub gas_fee_used: TokenAmount,
     /// Optional caller allowlist.

--- a/fendermint/actors/blobs/src/shared.rs
+++ b/fendermint/actors/blobs/src/shared.rs
@@ -2,9 +2,9 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_ipld_encoding::tuple::*;
-
 pub use crate::state::State;
+use fvm_ipld_encoding::tuple::*;
+use fvm_shared::bigint::BigInt;
 
 pub const BLOBS_ACTOR_NAME: &str = "blobs";
 
@@ -14,6 +14,6 @@ pub const BLOBS_ACTOR_NAME: &str = "blobs";
 pub struct ConstructorParams {
     /// The total storage capacity of the subnet.
     pub blob_capacity: u64,
-    /// The token to credit rate. The amount of credits that 1 atto buys.
-    pub token_credit_rate: u64,
+    /// The token to credit rate. The amount of atto credits that 1 atto buys.
+    pub token_credit_rate: BigInt,
 }

--- a/fendermint/actors/hoku_config/shared/src/lib.rs
+++ b/fendermint/actors/hoku_config/shared/src/lib.rs
@@ -6,6 +6,7 @@ use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::{deserialize_block, extract_send_result, ActorError};
 use fvm_ipld_encoding::tuple::*;
 use fvm_shared::address::Address;
+use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::sys::SendFlags;
 use fvm_shared::{ActorID, MethodNum, METHOD_CONSTRUCTOR};
@@ -20,8 +21,8 @@ pub const HOKU_CONFIG_ACTOR_ADDR: Address = Address::new_id(HOKU_CONFIG_ACTOR_ID
 pub struct HokuConfig {
     /// The total storage capacity of the subnet.
     pub blob_capacity: u64,
-    /// The token to credit rate. The amount of credits that 1 atto buys.
-    pub token_credit_rate: u64,
+    /// The token to credit rate. The amount of atto credits that 1 atto buys.
+    pub token_credit_rate: BigInt,
     /// Block interval at which to debit all credit accounts.
     pub blob_credit_debit_interval: ChainEpoch,
 }
@@ -30,7 +31,7 @@ impl Default for HokuConfig {
     fn default() -> Self {
         Self {
             blob_capacity: 10 * 1024 * 1024 * 1024 * 1024, // 10 TiB
-            token_credit_rate: 1,                          // 1 atto = 1 credit
+            token_credit_rate: BigInt::from(1_000_000_000_000_000_000u64), // 1 atto = 1 credit (1e18 atto credit)
             blob_credit_debit_interval: ChainEpoch::from(3600),
         }
     }

--- a/fendermint/actors/hoku_config/src/lib.rs
+++ b/fendermint/actors/hoku_config/src/lib.rs
@@ -10,6 +10,7 @@ use fil_actors_runtime::SYSTEM_ACTOR_ADDR;
 use fil_actors_runtime::{actor_dispatch, ActorError};
 use fvm_ipld_encoding::tuple::*;
 use fvm_shared::address::Address;
+use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
 
 #[cfg(feature = "fil-actor")]
@@ -28,7 +29,7 @@ pub struct State {
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone)]
 pub struct ConstructorParams {
     initial_blob_capacity: u64,
-    initial_token_credit_rate: u64,
+    initial_token_credit_rate: BigInt,
     initial_blob_credit_debit_interval: ChainEpoch,
 }
 
@@ -138,10 +139,11 @@ mod tests {
     use fil_actors_runtime::SYSTEM_ACTOR_ADDR;
     use fvm_ipld_encoding::ipld_block::IpldBlock;
     use fvm_shared::address::Address;
+    use fvm_shared::bigint::BigInt;
     use fvm_shared::clock::ChainEpoch;
 
     pub fn construct_and_verify(
-        token_credit_rate: u64,
+        token_credit_rate: BigInt,
         blob_capacity: u64,
         blob_credit_debit_interval: i32,
     ) -> MockRuntime {
@@ -175,7 +177,7 @@ mod tests {
 
     #[test]
     fn test_get_config() {
-        let rt = construct_and_verify(5, 1024, 3600);
+        let rt = construct_and_verify(BigInt::from(5), 1024, 3600);
 
         rt.expect_validate_caller_any();
         let hoku_config = rt
@@ -185,14 +187,14 @@ mod tests {
             .deserialize::<HokuConfig>()
             .unwrap();
 
-        assert_eq!(hoku_config.token_credit_rate, 5);
+        assert_eq!(hoku_config.token_credit_rate, BigInt::from(5));
         assert_eq!(hoku_config.blob_capacity, 1024);
         assert_eq!(hoku_config.blob_credit_debit_interval, 3600);
     }
 
     #[test]
     fn test_set_config() {
-        let rt = construct_and_verify(5, 1024, 3600);
+        let rt = construct_and_verify(BigInt::from(5), 1024, 3600);
 
         let id_addr = Address::new_id(110);
         let eth_addr = EthAddress(hex_literal::hex!(
@@ -208,7 +210,7 @@ mod tests {
             Method::SetConfig as u64,
             IpldBlock::serialize_cbor(&HokuConfig {
                 blob_capacity: 2048,
-                token_credit_rate: 10,
+                token_credit_rate: BigInt::from(10),
                 blob_credit_debit_interval: ChainEpoch::from(1800),
             })
             .unwrap(),
@@ -223,7 +225,7 @@ mod tests {
             .deserialize::<HokuConfig>()
             .unwrap();
 
-        assert_eq!(hoku_config.token_credit_rate, 10);
+        assert_eq!(hoku_config.token_credit_rate, BigInt::from(10));
         assert_eq!(hoku_config.blob_capacity, 2048);
         assert_eq!(hoku_config.blob_credit_debit_interval, 1800);
     }

--- a/fendermint/vm/interpreter/src/fvm/hoku_config.rs
+++ b/fendermint/vm/interpreter/src/fvm/hoku_config.rs
@@ -9,6 +9,7 @@ use fendermint_actor_hoku_config_shared::Method::GetConfig;
 use fendermint_vm_actor_interface::hoku_config::HOKU_CONFIG_ACTOR_ADDR;
 use fendermint_vm_actor_interface::system;
 use fvm::executor::{ApplyKind, ApplyRet, Executor};
+use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
 use num_traits::Zero;
 
@@ -17,8 +18,8 @@ use num_traits::Zero;
 pub struct HokuConfigTracker {
     /// The total storage capacity of the subnet.
     pub blob_capacity: u64,
-    /// The token to credit rate. The amount of credits that 1 atto buys.
-    pub token_credit_rate: u64,
+    /// The token to credit rate. The amount of atto credits that 1 atto buys.
+    pub token_credit_rate: BigInt,
     /// Block interval at which to debit all credit accounts.
     pub blob_credit_debit_interval: ChainEpoch,
 }


### PR DESCRIPTION
# Summary

Credits are represented as multiples of attos now.

# Context
This is needed to avoid a decimal representation of `token_credit_rate`. Suppose we want a `token_credit_rate` of 1 Hoku = 0.5 credit. For that we would need a `f64` type, or any other decimal representation, for `token_credit_rate`. That would lead to a bunch of problems.

By using attos for credits, we can do 1 Hoku = 500000000000000000 atto credits.

We can't do 1 atto = 0.5 atto credit, but that kind of precision will probably be not needed.

This PR branches off https://github.com/hokunet/ipc/pull/405

Related to https://github.com/hokunet/ipc/issues/388

# Changes
The gist of the PR is:
- Adds a new type [`Credit`](https://github.com/hokunet/ipc/pull/411/files#diff-732ecaf2caff3ea98ad38ab0d514481f98a542238bdd0a10faded80f1b6f1941R19) and refactor all credit values to use that type
- Changes the type of `token_credit_rate` to `BigInt` because `u64` might not be enough
- Changes code and tests to adjust to the above