### PR TITLE
feat: set chain ID in fendermint infra, localnet

### DIFF
--- a/infra/fendermint/Makefile.toml
+++ b/infra/fendermint/Makefile.toml
@@ -24,6 +24,7 @@ default_to_workspace = false
 [env]
 # General network-specific parameters
 SUBNET_ID = { value = "/r0", condition = { env_not_set = ["SUBNET_ID"] } }
+CHAIN_ID = { value = "", condition = { env_not_set = ["CHAIN_ID"] } }
 # The network name is derived from the SUBNET_ID, replacing slashes with dashes, and dropping the first dash if any.
 NETWORK_NAME = { script = ["echo $SUBNET_ID | sed -e 's|/|-|g' -e 's|^-||1'"] }
 # External P2P address advertised by CometBFT to other peers.

--- a/infra/fendermint/scripts/subnet.toml
+++ b/infra/fendermint/scripts/subnet.toml
@@ -129,6 +129,7 @@ dependencies = [
 [tasks.subnet-config]
 dependencies = [
     "subnet-fetch-genesis",
+    "subnet-genesis-set-chain-id",
     "subnet-genesis-set-eam-permissions",
     "genesis-seal",
     "genesis-write",
@@ -150,6 +151,15 @@ script.pre = "mkdir -p ${BASE_DIR}/${NODE_NAME}/${KEYS_SUBDIR}; cp ${PRIVATE_KEY
 [tasks.subnet-fetch-genesis]
 extend = "fendermint-tool"
 env = { "CMD" = "genesis --genesis-file /data/genesis.json ipc from-parent --subnet-id ${SUBNET_ID} -p ${PARENT_ENDPOINT} ${PARENT_AUTH_FLAG} --parent-gateway ${PARENT_GATEWAY} --parent-registry ${PARENT_REGISTRY} --base-fee ${BASE_FEE} --power-scale ${POWER_SCALE}" }
+
+[tasks.subnet-genesis-set-chain-id]
+extend = "fendermint-tool"
+script.pre = """
+#!/bin/bash
+if [[ ! -z ${CHAIN_ID} ]]; then
+  CMD="genesis --genesis-file /data/genesis.json set-chain-id --chain-id ${CHAIN_ID}"
+fi
+"""
 
 [tasks.subnet-genesis-set-eam-permissions]
 extend = "fendermint-tool"

--- a/scripts/deploy_subnet/deploy.sh
+++ b/scripts/deploy_subnet/deploy.sh
@@ -310,6 +310,16 @@ cp "$IPC_FOLDER"/infra/loki/loki-config.yaml "$IPC_CONFIG_FOLDER"
 cp "$IPC_FOLDER"/infra/promtail/promtail-config.yaml "$IPC_CONFIG_FOLDER"
 cp "$IPC_FOLDER"/infra/iroh/iroh.config.toml "$IPC_CONFIG_FOLDER"
 
+# Explicitly set the chain ID if not provided
+if [[ -z ${CHAIN_ID+x} ]]; then
+  if [[ $local_deploy == true ]]; then
+    CHAIN_ID=248163216
+  else
+    CHAIN_ID=2481632
+  fi
+fi
+echo "Using chain ID: $CHAIN_ID"
+
 if [[ -z ${SKIP_BUILD+x} || "$SKIP_BUILD" == "" || "$SKIP_BUILD" == "false" ]]; then
   # Build contracts
   echo "$DASHES Building ipc contracts..."
@@ -572,6 +582,7 @@ bootstrap_output=$(cargo make --makefile infra/fendermint/Makefile.toml \
     -e NODE_NAME=validator-0 \
     -e PRIVATE_KEY_PATH="${IPC_CONFIG_FOLDER}"/validator_0.sk \
     -e SUBNET_ID="${subnet_id}" \
+    -e CHAIN_ID="${CHAIN_ID}" \
     -e PARENT_ENDPOINT="${PARENT_ENDPOINT}" \
     -e CMT_P2P_HOST_PORT="${CMT_P2P_HOST_PORTS[0]}" \
     -e CMT_RPC_HOST_PORT="${CMT_RPC_HOST_PORTS[0]}" \
@@ -611,6 +622,7 @@ do
       -e NODE_NAME=validator-"${i}" \
       -e PRIVATE_KEY_PATH="${IPC_CONFIG_FOLDER}"/validator_"${i}".sk \
       -e SUBNET_ID="${subnet_id}" \
+      -e CHAIN_ID="${CHAIN_ID}" \
       -e PARENT_ENDPOINT="${PARENT_ENDPOINT}" \
       -e CMT_P2P_HOST_PORT="${CMT_P2P_HOST_PORTS[i]}" \
       -e CMT_RPC_HOST_PORT="${CMT_RPC_HOST_PORTS[i]}" \
@@ -837,8 +849,8 @@ Subnet registry:        0x74539671a1d2f1c8f200826baba665179f53a1b7
 EOF
 
 if [[ $local_deploy = true ]]; then
-  echo "Subnet blob manager:   ${BLOB_MANAGER_ADDRESS}"
-  echo "Subnet bucket manager: ${BUCKET_MANAGER_ADDRESS}"
+  echo "Subnet blob manager:    ${BLOB_MANAGER_ADDRESS}"
+  echo "Subnet bucket manager:  ${BUCKET_MANAGER_ADDRESS}"
   echo "Subnet credit manager:  ${CREDIT_MANAGER_ADDRESS}"
   echo
   echo "Account balances:"


### PR DESCRIPTION
## Summary

- Add a new fendermint infra task for setting the chain ID.
- Update localnet to use `248163216`

## Details

Tested against the latest `hoku` CLI on localnet—it works.