### PR TITLE
refactor: create type for token credit rate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,6 +3246,7 @@ dependencies = [
 name = "fendermint_actor_hoku_config"
 version = "0.1.0"
 dependencies = [
+ "fendermint_actor_blobs_shared",
  "fendermint_actor_hoku_config_shared",
  "fendermint_actor_machine",
  "fil_actors_evm_shared",
@@ -3262,6 +3263,7 @@ dependencies = [
 name = "fendermint_actor_hoku_config_shared"
 version = "0.1.0"
 dependencies = [
+ "fendermint_actor_blobs_shared",
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_ipld_encoding",

--- a/fendermint/actors/blobs/shared/src/params.rs
+++ b/fendermint/actors/blobs/shared/src/params.rs
@@ -4,13 +4,14 @@
 
 use fvm_ipld_encoding::tuple::*;
 use fvm_shared::address::Address;
-use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
-use crate::state::{BlobStatus, Credit, Hash, PublicKey, SubscriptionId, TtlStatus};
+use crate::state::{
+    BlobStatus, Credit, Hash, PublicKey, SubscriptionId, TokenCreditRate, TtlStatus,
+};
 
 /// Params for buying credits.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -227,8 +228,8 @@ pub struct GetStatsReturn {
     pub credit_committed: Credit,
     /// The total number of credits debited in the subnet.
     pub credit_debited: Credit,
-    /// The token to credit rate. The amount of atto credits that 1 atto buys.
-    pub token_credit_rate: BigInt,
+    /// The token to credit rate.
+    pub token_credit_rate: TokenCreditRate,
     /// Total number of debit accounts.
     pub num_accounts: u64,
     /// Total number of actively stored blobs.

--- a/fendermint/actors/blobs/shared/src/state.rs
+++ b/fendermint/actors/blobs/shared/src/state.rs
@@ -5,16 +5,56 @@
 use fil_actors_runtime::ActorError;
 use fvm_ipld_encoding::tuple::*;
 use fvm_shared::address::Address;
+use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use hoku_ipld::hamt::MapKey;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::fmt::Display;
+use std::ops::{Div, Mul};
 
 /// Credit is counted the same way as tokens.
 /// The smallest indivisible unit is 1 atto, and 1 credit = 1e18 atto credits.
 pub type Credit = TokenAmount;
+
+/// TokenCreditRate determines how much atto credits can be bought by a certain amount of HOKU.
+#[derive(Clone, Default, Debug, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
+pub struct TokenCreditRate {
+    rate: BigInt,
+}
+
+impl TokenCreditRate {
+    pub const RATIO: u128 = 10u128.pow(18);
+
+    pub fn from(rate: impl Into<BigInt>) -> Self {
+        Self { rate: rate.into() }
+    }
+}
+
+impl Display for TokenCreditRate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.rate)
+    }
+}
+
+impl Mul<&TokenCreditRate> for TokenAmount {
+    type Output = Credit;
+
+    fn mul(self, rate: &TokenCreditRate) -> Self::Output {
+        (self * &rate.rate).div_floor(TokenCreditRate::RATIO)
+    }
+}
+
+impl<'a> Div<&TokenCreditRate> for &'a Credit {
+    type Output = TokenAmount;
+
+    fn div(self, rate: &TokenCreditRate) -> Self::Output {
+        #[allow(clippy::suspicious_arithmetic_impl)]
+        (self * TokenCreditRate::RATIO).div_floor(rate.rate.clone())
+    }
+}
 
 /// The stored representation of a credit account.
 #[derive(Clone, Debug, Default, PartialEq, Serialize_tuple, Deserialize_tuple)]
@@ -337,7 +377,7 @@ pub enum BlobStatus {
     Failed,
 }
 
-impl fmt::Display for BlobStatus {
+impl Display for BlobStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             BlobStatus::Added => write!(f, "added"),
@@ -389,12 +429,97 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_subsciption_id_length() {
+    fn test_subscription_id_length() {
         let id_str = |len: usize| "a".repeat(len);
         let id = SubscriptionId::new(&id_str(SubscriptionId::MAX_LEN)).unwrap();
         assert_eq!(id.inner, id_str(SubscriptionId::MAX_LEN));
 
         let id = SubscriptionId::new(&id_str(SubscriptionId::MAX_LEN + 1));
         assert!(id.is_err());
+    }
+
+    #[test]
+    fn test_token_credit_rate() {
+        struct TestCase {
+            tokens: TokenAmount,
+            rate: TokenCreditRate,
+            expected: &'static str,
+            description: &'static str,
+        }
+
+        let test_cases = vec![
+            TestCase {
+                tokens: TokenAmount::from_whole(1),
+                rate: TokenCreditRate::from(BigInt::from(1)),
+                expected: "0.000000000000000001",
+                description: "lower bound: 1 HOKU buys 1 atto credit",
+            },
+            TestCase {
+                tokens: TokenAmount::from_nano(BigInt::from(500000000)), // 0.5 HOKU
+                rate: TokenCreditRate::from(BigInt::from(1)),
+                expected: "0.0",
+                description: "crossing lower bound. 0.5 HOKU cannot buy 1 atto credit",
+            },
+            TestCase {
+                tokens: TokenAmount::from_whole(BigInt::from(1)),
+                rate: TokenCreditRate::from(BigInt::from(2)),
+                expected: "0.000000000000000002",
+                description: "1 HOKU buys 2 atto credits",
+            },
+            TestCase {
+                tokens: TokenAmount::from_whole(BigInt::from(1)),
+                rate: TokenCreditRate::from(BigInt::from(10u64.pow(18))),
+                expected: "1.0",
+                description: "1 HOKU buys 1 whole credit",
+            },
+            TestCase {
+                tokens: TokenAmount::from_whole(BigInt::from(50)),
+                rate: TokenCreditRate::from(BigInt::from(10u64.pow(18))),
+                expected: "50.0",
+                description: "50 HOKU buys 50 whole credits",
+            },
+            TestCase {
+                tokens: TokenAmount::from_nano(BigInt::from(233432100u64)),
+                rate: TokenCreditRate::from(BigInt::from(10u64.pow(18))),
+                expected: "0.2334321",
+                description: "0.2334321 HOKU buys 0.2334321 credits",
+            },
+            TestCase {
+                tokens: TokenAmount::from_nano(BigInt::from(233432100u64)),
+                rate: TokenCreditRate::from(BigInt::from(10u128.pow(36))),
+                expected: "233432100000000000.0",
+                description: "0.2334321 HOKU buys 233432100000000000 credits",
+            },
+            TestCase {
+                tokens: TokenAmount::from_atto(BigInt::from(1)), // 1 attoHOKU
+                rate: TokenCreditRate::from(BigInt::from(10u128.pow(36))),
+                expected: "1.0",
+                description: "1 atto HOKU buys 1 credit",
+            },
+            TestCase {
+                tokens: TokenAmount::from_whole(BigInt::from(1)),
+                rate: TokenCreditRate::from(BigInt::from(10u128.pow(18)).div(4)),
+                expected: "0.25",
+                description: "1 HOKU buys 0.25 credit",
+            },
+            TestCase {
+                tokens: TokenAmount::from_whole(BigInt::from(1)),
+                rate: TokenCreditRate::from(BigInt::from(10u128.pow(18)).div(3)),
+                expected: "0.333333333333333333",
+                description: "1 HOKU buys 0.333333333333333333 credit",
+            },
+        ];
+
+        for t in test_cases {
+            let credits = t.tokens.clone() * &t.rate;
+            assert_eq!(
+                t.expected,
+                credits.to_string(),
+                "tc: {}, {}, {}",
+                t.description,
+                t.tokens,
+                t.rate
+            );
+        }
     }
 }

--- a/fendermint/actors/hoku_config/Cargo.toml
+++ b/fendermint/actors/hoku_config/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.1.0"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
+fendermint_actor_blobs_shared = { path = "../blobs/shared" }
 fil_actors_runtime = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_shared = { workspace = true }

--- a/fendermint/actors/hoku_config/shared/Cargo.toml
+++ b/fendermint/actors/hoku_config/shared/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.1.0"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
+fendermint_actor_blobs_shared = { path = "../../blobs/shared" }
 fil_actors_runtime = { workspace = true }
 frc42_dispatch = { workspace = true }
 fvm_ipld_encoding = { workspace = true }

--- a/fendermint/actors/hoku_config/shared/src/lib.rs
+++ b/fendermint/actors/hoku_config/shared/src/lib.rs
@@ -2,6 +2,7 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use fendermint_actor_blobs_shared::state::TokenCreditRate;
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::{deserialize_block, extract_send_result, ActorError};
 use fvm_ipld_encoding::tuple::*;
@@ -23,8 +24,8 @@ pub const HOKU_CONFIG_ACTOR_ADDR: Address = Address::new_id(HOKU_CONFIG_ACTOR_ID
 pub struct HokuConfig {
     /// The total storage capacity of the subnet.
     pub blob_capacity: u64,
-    /// The token to credit rate. The amount of atto credits that 1 atto buys.
-    pub token_credit_rate: BigInt,
+    /// The token to credit rate.
+    pub token_credit_rate: TokenCreditRate,
     /// Block interval at which to debit all credit accounts.
     pub blob_credit_debit_interval: ChainEpoch,
     /// The minimum epoch duration a blob can be stored.
@@ -37,7 +38,8 @@ impl Default for HokuConfig {
     fn default() -> Self {
         Self {
             blob_capacity: 10 * 1024 * 1024 * 1024 * 1024, // 10 TiB
-            token_credit_rate: BigInt::from(1_000_000_000_000_000_000u64), // 1 atto = 1 credit (1e18 atto credit)
+            // 1 HOKU buys 1e18 credits ~ 1 HOKU buys 1e36 atto credits.
+            token_credit_rate: TokenCreditRate::from(BigInt::from(10u128.pow(36))),
             blob_credit_debit_interval: ChainEpoch::from(3600),
             blob_min_ttl: ChainEpoch::from(3600),
             blob_auto_renew_ttl: ChainEpoch::from(3600),

--- a/fendermint/actors/hoku_config/src/lib.rs
+++ b/fendermint/actors/hoku_config/src/lib.rs
@@ -2,6 +2,7 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use fendermint_actor_blobs_shared::state::TokenCreditRate;
 use fendermint_actor_hoku_config_shared::{HokuConfig, Method, SetAdminParams, SetConfigParams};
 use fendermint_actor_machine::resolve_external;
 use fil_actors_runtime::actor_error;
@@ -10,7 +11,6 @@ use fil_actors_runtime::SYSTEM_ACTOR_ADDR;
 use fil_actors_runtime::{actor_dispatch, ActorError};
 use fvm_ipld_encoding::tuple::*;
 use fvm_shared::address::Address;
-use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
 
 #[cfg(feature = "fil-actor")]
@@ -29,7 +29,7 @@ pub struct State {
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone)]
 pub struct ConstructorParams {
     initial_blob_capacity: u64,
-    initial_token_credit_rate: BigInt,
+    initial_token_credit_rate: TokenCreditRate,
     initial_blob_credit_debit_interval: ChainEpoch,
     initial_blob_min_ttl: ChainEpoch,
     initial_blob_auto_renew_ttl: ChainEpoch,
@@ -135,6 +135,7 @@ impl ActorCode for Actor {
 #[cfg(test)]
 mod tests {
     use crate::{Actor, ConstructorParams, Method};
+    use fendermint_actor_blobs_shared::state::TokenCreditRate;
     use fendermint_actor_hoku_config_shared::{HokuConfig, HOKU_CONFIG_ACTOR_ID};
     use fil_actors_evm_shared::address::EthAddress;
     use fil_actors_runtime::test_utils::{
@@ -147,7 +148,7 @@ mod tests {
     use fvm_shared::clock::ChainEpoch;
 
     pub fn construct_and_verify(
-        token_credit_rate: BigInt,
+        token_credit_rate: TokenCreditRate,
         blob_capacity: u64,
         blob_credit_debit_interval: i32,
         initial_blob_min_ttl: ChainEpoch,
@@ -185,7 +186,13 @@ mod tests {
 
     #[test]
     fn test_get_config() {
-        let rt = construct_and_verify(BigInt::from(5), 1024, 3600, 3600, 3600);
+        let rt = construct_and_verify(
+            TokenCreditRate::from(BigInt::from(5)),
+            1024,
+            3600,
+            3600,
+            3600,
+        );
 
         rt.expect_validate_caller_any();
         let hoku_config = rt
@@ -195,14 +202,23 @@ mod tests {
             .deserialize::<HokuConfig>()
             .unwrap();
 
-        assert_eq!(hoku_config.token_credit_rate, BigInt::from(5));
+        assert_eq!(
+            hoku_config.token_credit_rate,
+            TokenCreditRate::from(BigInt::from(5))
+        );
         assert_eq!(hoku_config.blob_capacity, 1024);
         assert_eq!(hoku_config.blob_credit_debit_interval, 3600);
     }
 
     #[test]
     fn test_set_config() {
-        let rt = construct_and_verify(BigInt::from(5), 1024, 3600, 3600, 3600);
+        let rt = construct_and_verify(
+            TokenCreditRate::from(BigInt::from(5)),
+            1024,
+            3600,
+            3600,
+            3600,
+        );
 
         let id_addr = Address::new_id(110);
         let eth_addr = EthAddress(hex_literal::hex!(
@@ -218,7 +234,7 @@ mod tests {
             Method::SetConfig as u64,
             IpldBlock::serialize_cbor(&HokuConfig {
                 blob_capacity: 2048,
-                token_credit_rate: BigInt::from(10),
+                token_credit_rate: TokenCreditRate::from(BigInt::from(10)),
                 blob_credit_debit_interval: ChainEpoch::from(1800),
                 blob_min_ttl: ChainEpoch::from(2 * 60 * 60),
                 blob_auto_renew_ttl: ChainEpoch::from(24 * 60 * 60),
@@ -235,7 +251,10 @@ mod tests {
             .deserialize::<HokuConfig>()
             .unwrap();
 
-        assert_eq!(hoku_config.token_credit_rate, BigInt::from(10));
+        assert_eq!(
+            hoku_config.token_credit_rate,
+            TokenCreditRate::from(BigInt::from(10))
+        );
         assert_eq!(hoku_config.blob_capacity, 2048);
         assert_eq!(hoku_config.blob_credit_debit_interval, 1800);
         assert_eq!(hoku_config.blob_min_ttl, ChainEpoch::from(2 * 60 * 60));

--- a/fendermint/vm/interpreter/src/fvm/hoku_config.rs
+++ b/fendermint/vm/interpreter/src/fvm/hoku_config.rs
@@ -4,6 +4,7 @@
 
 use crate::fvm::FvmMessage;
 use anyhow::{bail, Context};
+use fendermint_actor_blobs_shared::state::TokenCreditRate;
 use fendermint_actor_hoku_config_shared::HokuConfig;
 use fendermint_actor_hoku_config_shared::Method::GetConfig;
 use fendermint_vm_actor_interface::hoku_config::HOKU_CONFIG_ACTOR_ADDR;
@@ -18,8 +19,8 @@ use num_traits::Zero;
 pub struct HokuConfigTracker {
     /// The total storage capacity of the subnet.
     pub blob_capacity: u64,
-    /// The token to credit rate. The amount of atto credits that 1 atto buys.
-    pub token_credit_rate: BigInt,
+    /// The token to credit rate.
+    pub token_credit_rate: TokenCreditRate,
     /// Block interval at which to debit all credit accounts.
     pub blob_credit_debit_interval: ChainEpoch,
     /// The minimum epoch duration a blob can be stored.
@@ -32,7 +33,7 @@ impl HokuConfigTracker {
     pub fn create<E: Executor>(executor: &mut E) -> anyhow::Result<HokuConfigTracker> {
         let mut ret = Self {
             blob_capacity: Zero::zero(),
-            token_credit_rate: Zero::zero(),
+            token_credit_rate: TokenCreditRate::from(BigInt::zero()),
             blob_credit_debit_interval: Zero::zero(),
             blob_min_ttl: Zero::zero(),
             blob_auto_renew_ttl: Zero::zero(),


### PR DESCRIPTION
# Summary

Create a new type `TokenCreditRate`:
- makes operating with token credit rate easier
- isolates the behavior of the rate
- makes it easier to reason about it

# Context

This PR aims to make it easier to deal with `TokenCreditRate`. Here's the behavior we aim to achieve:

1) We want a token to credit rate so that **1 HOKU buys X amount of atto credits**. That is,

$$ X_{atto \ credits} = tokens_{HOKU} * rate_{atto \ credits/HOKU} $$

Why?

That ratio gives us:

  - **Unbounded upper limit**. If the token appreciates, that means we can buy more credits with the same token amount. And there's no limit to how much credit we can buy with a token.
  - **Bounded lower limit with more than enough room**: If the token depreciates, we can buy fewer credits with the same token amount. The point where the token is less valued is when `rate = 1`, that is, **1 HOKU buys 1 atto credit**.
    

2) The default token rate is: **1 HOKU buys $10^{18}$ credits**

    For that, we need to make [`token_credit_rate = 10^36`](https://github.com/hokunet/ipc/pull/418/files#diff-2ac9707b3f050061795fe1a94722dfbfd72e541df6267c7f50fa715bfa669a07R42)

3) With that default rate, the least amount of credits we can buy is **1** with one **attoHOKU**. I cannot buy less than one credit. 


Take a look at the [test cases](https://github.com/hokunet/ipc/pull/418/files#diff-732ecaf2caff3ea98ad38ab0d514481f98a542238bdd0a10faded80f1b6f1941R442) and see if they make sense.

If that behavior is not what we want, or the implementation does not capture that, let me know.
