### PR TITLE
chore: use target/release before path to use correct fendermint bin in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ lint: license $(patsubst %, lint/%, $(SUBTREES_ALL))
 ## Hoku
 
 config-devnet:
-	PATH="$(PATH):./target/release" \
+	PATH="./target/release:$(PATH)" \
 	./scripts/setup.sh
 
 run-devnet-iroh:


### PR DESCRIPTION
If you run `make install fendermint` you'll get a version on your path and be confused when things don't work as you expect when trying to use `make config devnet`. Now we make sure the `target/release/fendermint` binary takes precedence over path.