### PR TITLE
fix: allow single byte range request

### DIFF
--- a/fendermint/app/src/cmd/objects.rs
+++ b/fendermint/app/src/cmd/objects.rs
@@ -523,7 +523,7 @@ fn get_range_params(range: String, size: u64) -> Result<(u64, u64), ObjectsError
         }
         (false, false) => (0, size - 1),
     };
-    if first >= last {
+    if first > last || first >= size {
         return Err(ObjectsError::RangeHeaderInvalid);
     }
     if last >= size {
@@ -1313,8 +1313,12 @@ mod tests {
         let _ = get_range_params("bytes=-50-".into(), 100).is_err();
         // first > last
         let _ = get_range_params("bytes=50-0".into(), 100).is_err();
+        // first >= size
+        let _ = get_range_params("bytes=100-".into(), 100).is_err();
         // first == last
-        let _ = get_range_params("bytes=0-0".into(), 100).is_err();
+        let (first, last) = get_range_params("bytes=0-0".into(), 100).unwrap();
+        assert_eq!(first, 0);
+        assert_eq!(last, 0);
         // exact range given
         let (first, last) = get_range_params("bytes=0-50".into(), 100).unwrap();
         assert_eq!(first, 0);


### PR DESCRIPTION
Single byte range requests fail—e.g., you can't grab the first byte like `range=0-0` since the first/last in the range are inclusive, and we reject `first >= last`.

This changes the logic to check:
- If `first > last` _or_ `first >= size`, then we reject the request
- Allow `first == last` so you can grab a single byte