### PR TITLE
fix: don't assume GOPATH and foundryup in scripts

### DIFF
--- a/scripts/deploy_subnet/deploy.sh
+++ b/scripts/deploy_subnet/deploy.sh
@@ -183,7 +183,7 @@ if [[ -z ${SKIP_DEPENDENCIES+x} || "$SKIP_DEPENDENCIES" == "" || "$SKIP_DEPENDEN
     fi
     # Check Foundry
     echo "$DASHES Check foundry..."
-    if which foundryup &> /dev/null ; then
+    if which anvil &> /dev/null ; then
       echo "$DASHES foundry is already installed."
     else
       echo "$DASHES Need to install foundry"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-GOPATH="${GOPATH:-$HOME/go}"
 export FM_NETWORK=test
 
 # Clean up old network files
@@ -16,7 +15,7 @@ cp -r ./fendermint/app/config "$HOME/.fendermint/config"
 
 # Init CometBFT
 rm -rf "$HOME/.cometbft"
-"$GOPATH/bin/cometbft" init
+cometbft init
 
 # Build actors
 if [[ -z ${SKIP_BUILD+x} || "$SKIP_BUILD" == "" || "$SKIP_BUILD" == "false" ]]; then


### PR DESCRIPTION
These changes make the scrips more flexible by not assuming that `cometbft` is installed in `$GOPATH/bin` and that `foundryup` is installed.