### PR TITLE
fix: length-prefixed encoding of request-id hash input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3112,6 +3112,7 @@ dependencies = [
  "rand",
  "serde",
  "sha2 0.10.8",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]

--- a/fendermint/actors/blob_reader/Cargo.toml
+++ b/fendermint/actors/blob_reader/Cargo.toml
@@ -21,6 +21,7 @@ frc42_dispatch = { workspace = true }
 num-derive = { workspace = true }
 sha2 = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+unsigned-varint = "0.8.0"
 
 fendermint_actor_blobs_shared = { path = "../blobs/shared" }
 

--- a/fendermint/actors/blob_reader/src/actor.rs
+++ b/fendermint/actors/blob_reader/src/actor.rs
@@ -118,7 +118,7 @@ impl ActorCode for ReadReqActor {
 mod tests {
     use super::*;
 
-    use crate::state::pad_to_32_bytes;
+    use crate::state::length_prefixed_bytes;
     use fil_actors_evm_shared::address::EthAddress;
     use fil_actors_runtime::test_utils::{
         expect_empty, MockRuntime, ETHACCOUNT_ACTOR_CODE_ID, SYSTEM_ACTOR_CODE_ID,
@@ -198,11 +198,11 @@ mod tests {
         let mut hasher = sha2::Sha256::new();
         hasher.update(
             [
-                &pad_to_32_bytes(blob_hash.0.as_ref())[..],
-                &pad_to_32_bytes(&offset.to_be_bytes())[..],
-                &pad_to_32_bytes(&len.to_be_bytes())[..],
-                &pad_to_32_bytes(&f4_eth_addr.to_bytes())[..],
-                &pad_to_32_bytes(&callback_method.to_be_bytes())[..],
+                &length_prefixed_bytes(blob_hash.0.as_ref())[..],
+                &length_prefixed_bytes(&offset.to_be_bytes())[..],
+                &length_prefixed_bytes(&len.to_be_bytes())[..],
+                &length_prefixed_bytes(&f4_eth_addr.to_bytes())[..],
+                &length_prefixed_bytes(&callback_method.to_be_bytes())[..],
             ]
             .concat(),
         );


### PR DESCRIPTION
Expected to fix https://github.com/hokunet/ipc/issues/472

BEWARE: Changed 32-padding to length-prefixed encoding, where length is encoded as [unsigned-varint](https://github.com/multiformats/unsigned-varint)

@avichalp Would really love your input.