### PR TITLE
fix: counter as hash

### DIFF
--- a/fendermint/actors/blob_reader/src/state.rs
+++ b/fendermint/actors/blob_reader/src/state.rs
@@ -8,7 +8,6 @@ use fil_actors_runtime::ActorError;
 use fvm_ipld_encoding::tuple::*;
 use fvm_shared::{address::Address, MethodNum};
 use log::info;
-use sha2::{Digest, Sha256};
 
 use crate::shared::{ReadRequest, ReadRequestStatus};
 use fendermint_actor_blobs_shared::state::Hash;
@@ -20,6 +19,8 @@ const MAX_READ_REQUEST_LEN: u32 = 1024 * 1024; // 1MB
 pub struct State {
     /// Map of read requests by request ID.
     pub read_requests: HashMap<Hash, ReadRequest>,
+    /// Counter to sequence the requests
+    pub request_id_counter: u64,
 }
 
 impl State {
@@ -30,7 +31,7 @@ impl State {
         len: u32,
         callback_addr: Address,
         callback_method: u64,
-    ) -> Result<(), ActorError> {
+    ) -> Result<Hash, ActorError> {
         // Validate length is not greater than the maximum allowed
         if len > MAX_READ_REQUEST_LEN {
             return Err(ActorError::illegal_argument(format!(
@@ -39,22 +40,7 @@ impl State {
             )));
         }
 
-        let blob_hash_bytes = pad_to_32_bytes(blob_hash.0.as_ref());
-        let offset_bytes = pad_to_32_bytes(&offset.to_be_bytes());
-        let len_bytes = pad_to_32_bytes(&len.to_be_bytes());
-        let callback_addr_bytes = pad_to_32_bytes(&callback_addr.to_bytes());
-        let callback_method_bytes = pad_to_32_bytes(&callback_method.to_be_bytes());
-        let combined_bytes: Vec<u8> = [
-            &blob_hash_bytes[..],
-            &offset_bytes[..],
-            &len_bytes[..],
-            &callback_addr_bytes[..],
-            &callback_method_bytes[..],
-        ]
-        .concat();
-        let mut hasher = Sha256::new();
-        hasher.update(&combined_bytes);
-        let request_id: [u8; 32] = hasher.finalize().into();
+        let request_id = self.next_request_id();
         let read_request = ReadRequest {
             blob_hash,
             offset,
@@ -64,9 +50,9 @@ impl State {
             status: ReadRequestStatus::Open,
         };
         info!("opening a read request onchain: {:?}", request_id);
-        // will overrite a previous request with the same hash
-        self.read_requests.insert(Hash(request_id), read_request);
-        Ok(())
+        // will create a new request even if the request parameters are the same
+        self.read_requests.insert(request_id, read_request);
+        Ok(request_id)
     }
 
     pub fn close_read_request(&mut self, request_id: Hash) -> Result<(), ActorError> {
@@ -102,7 +88,7 @@ impl State {
     }
 
     pub fn get_read_request_status(&self, id: Hash) -> Option<ReadRequestStatus> {
-        self.read_requests.get(&id).map(|req| req.status.clone())
+        self.read_requests.get(&id).map(|r| r.status.clone())
     }
 
     /// Set a read request status to pending.
@@ -122,11 +108,9 @@ impl State {
         request.status = ReadRequestStatus::Pending;
         Ok(())
     }
-}
 
-pub(crate) fn pad_to_32_bytes(input: &[u8]) -> [u8; 32] {
-    let mut padded = [0u8; 32];
-    let start = 32_usize.saturating_sub(input.len());
-    padded[start..].copy_from_slice(&input[..input.len().min(32)]);
-    padded
+    fn next_request_id(&mut self) -> Hash {
+        self.request_id_counter += 1;
+        Hash::from(self.request_id_counter)
+    }
 }

--- a/fendermint/actors/blobs/shared/src/state.rs
+++ b/fendermint/actors/blobs/shared/src/state.rs
@@ -181,6 +181,14 @@ impl TryFrom<&str> for Hash {
     }
 }
 
+impl From<u64> for Hash {
+    fn from(value: u64) -> Self {
+        let mut padded = [0u8; 32];
+        padded[24..].copy_from_slice(&value.to_be_bytes());
+        Self(padded)
+    }
+}
+
 /// Iroh node public key.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]


### PR DESCRIPTION
Expected to fix https://github.com/hokunet/ipc/issues/472

There is a counter inside. In order not to change internals of Hoku, `u64` counter bytes get wrapped into `Hash`.

BEWARE: It will add a new request even if request parameters are the same.