### PR TITLE
chore: fix ssh in new checkout

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,7 @@ jobs:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
+            ${{ secrets.IPC_DEPLOY_KEY }}
             ${{ secrets.BUILTIN_ACTORS_DEPLOY_KEY }}
             ${{ secrets.CONTRACTS_DEPLOY_KEY }}
             ${{ secrets.ENTANGLEMENT_DEPLOY_KEY }}
@@ -29,7 +30,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ssh-key: ${{ secrets.IPC_DEPLOY_KEY }}
 
       - name: Install Tools
         uses: ./.github/actions/install-tools

--- a/.github/workflows/contracts-deployment-test.yaml
+++ b/.github/workflows/contracts-deployment-test.yaml
@@ -12,12 +12,13 @@ jobs:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
+            ${{ secrets.IPC_DEPLOY_KEY }}
             ${{ secrets.BUILTIN_ACTORS_DEPLOY_KEY }}
             ${{ secrets.CONTRACTS_DEPLOY_KEY }}
             ${{ secrets.ENTANGLEMENT_DEPLOY_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v2
 

--- a/.github/workflows/contracts-pnpm-audit.yaml
+++ b/.github/workflows/contracts-pnpm-audit.yaml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/contracts-prettier.yaml
+++ b/.github/workflows/contracts-prettier.yaml
@@ -11,6 +11,7 @@ jobs:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
+            ${{ secrets.IPC_DEPLOY_KEY }}
             ${{ secrets.BUILTIN_ACTORS_DEPLOY_KEY }}
             ${{ secrets.CONTRACTS_DEPLOY_KEY }}
             ${{ secrets.ENTANGLEMENT_DEPLOY_KEY }}

--- a/.github/workflows/contracts-sast.yaml
+++ b/.github/workflows/contracts-sast.yaml
@@ -13,11 +13,12 @@ jobs:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
+            ${{ secrets.IPC_DEPLOY_KEY }}
             ${{ secrets.BUILTIN_ACTORS_DEPLOY_KEY }}
             ${{ secrets.CONTRACTS_DEPLOY_KEY }}
             ${{ secrets.ENTANGLEMENT_DEPLOY_KEY }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -34,6 +35,7 @@ jobs:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
+            ${{ secrets.IPC_DEPLOY_KEY }}
             ${{ secrets.BUILTIN_ACTORS_DEPLOY_KEY }}
             ${{ secrets.CONTRACTS_DEPLOY_KEY }}
             ${{ secrets.ENTANGLEMENT_DEPLOY_KEY }}

--- a/.github/workflows/contracts-storage.yaml
+++ b/.github/workflows/contracts-storage.yaml
@@ -17,11 +17,12 @@ jobs:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
+            ${{ secrets.IPC_DEPLOY_KEY }}
             ${{ secrets.BUILTIN_ACTORS_DEPLOY_KEY }}
             ${{ secrets.CONTRACTS_DEPLOY_KEY }}
             ${{ secrets.ENTANGLEMENT_DEPLOY_KEY }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/contracts-test.yaml
+++ b/.github/workflows/contracts-test.yaml
@@ -12,6 +12,7 @@ jobs:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
+            ${{ secrets.IPC_DEPLOY_KEY }}
             ${{ secrets.BUILTIN_ACTORS_DEPLOY_KEY }}
             ${{ secrets.CONTRACTS_DEPLOY_KEY }}
             ${{ secrets.ENTANGLEMENT_DEPLOY_KEY }}
@@ -20,7 +21,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ssh-key: ${{ secrets.IPC_DEPLOY_KEY }}
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -24,6 +24,7 @@ jobs:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
+            ${{ secrets.IPC_DEPLOY_KEY }}
             ${{ secrets.BUILTIN_ACTORS_DEPLOY_KEY }}
             ${{ secrets.CONTRACTS_DEPLOY_KEY }}
             ${{ secrets.ENTANGLEMENT_DEPLOY_KEY }}
@@ -32,7 +33,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ssh-key: ${{ secrets.IPC_DEPLOY_KEY }}
 
       - name: Collect Git and SSH config files in a directory that is part of the Docker build context
         run: |

--- a/.github/workflows/extras.yaml
+++ b/.github/workflows/extras.yaml
@@ -19,6 +19,7 @@ jobs:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
+            ${{ secrets.IPC_DEPLOY_KEY }}
             ${{ secrets.BUILTIN_ACTORS_DEPLOY_KEY }}
             ${{ secrets.CONTRACTS_DEPLOY_KEY }}
             ${{ secrets.ENTANGLEMENT_DEPLOY_KEY }}

--- a/.github/workflows/fevm-contract-tests.yaml
+++ b/.github/workflows/fevm-contract-tests.yaml
@@ -11,6 +11,7 @@ jobs:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
+            ${{ secrets.IPC_DEPLOY_KEY }}
             ${{ secrets.BUILTIN_ACTORS_DEPLOY_KEY }}
             ${{ secrets.CONTRACTS_DEPLOY_KEY }}
             ${{ secrets.ENTANGLEMENT_DEPLOY_KEY }}

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -12,12 +12,13 @@ jobs:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
+            ${{ secrets.IPC_DEPLOY_KEY }}
             ${{ secrets.BUILTIN_ACTORS_DEPLOY_KEY }}
             ${{ secrets.CONTRACTS_DEPLOY_KEY }}
             ${{ secrets.ENTANGLEMENT_DEPLOY_KEY }}
 
       - name: Check out the project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # This is so `make license` doesn't say "bad revision origin/main"
       - name: Fetch origin for diff

--- a/.github/workflows/tests-e2e.yaml
+++ b/.github/workflows/tests-e2e.yaml
@@ -21,6 +21,7 @@ jobs:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
+            ${{ secrets.IPC_DEPLOY_KEY }}
             ${{ secrets.BUILTIN_ACTORS_DEPLOY_KEY }}
             ${{ secrets.CONTRACTS_DEPLOY_KEY }}
             ${{ secrets.ENTANGLEMENT_DEPLOY_KEY }}
@@ -29,7 +30,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ssh-key: ${{ secrets.IPC_DEPLOY_KEY }}
 
       - name: Install Tools
         uses: ./.github/actions/install-tools

--- a/.github/workflows/tests-unit.yaml
+++ b/.github/workflows/tests-unit.yaml
@@ -21,6 +21,7 @@ jobs:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
+            ${{ secrets.IPC_DEPLOY_KEY }}
             ${{ secrets.BUILTIN_ACTORS_DEPLOY_KEY }}
             ${{ secrets.CONTRACTS_DEPLOY_KEY }}
             ${{ secrets.ENTANGLEMENT_DEPLOY_KEY }}
@@ -29,7 +30,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ssh-key: ${{ secrets.IPC_DEPLOY_KEY }}
 
       - name: Install Tools
         uses: ./.github/actions/install-tools

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,4 +16,3 @@
 [submodule "recall-contracts"]
 	path = recall-contracts
 	url = git@github.com:recallnet/contracts.git
-	branch = joe/rename


### PR DESCRIPTION
I cleaned up the ssh keys on the existing runner, and everything started to fail. so we had two failing runners. turns out that when you have a step like:

```
    steps:
      - uses: webfactory/ssh-agent@v0.9.0
        with:
          ssh-private-key: |
            ${{ secrets.IPC_DEPLOY_KEY }}
            ${{ secrets.BUILTIN_ACTORS_DEPLOY_KEY }}
            ${{ secrets.CONTRACTS_DEPLOY_KEY }}
            ${{ secrets.ENTANGLEMENT_DEPLOY_KEY }}

      - name: Check out the project
        uses: actions/checkout@v4
        with:
          submodules: recursive
```

you _do not_ want to put an ssh-key under the checkout step, because it will try to use that key for all submodules as well as the main repo. so, you have to put the main key in the `ssh-agent` step above as well. 

i'm not sure how it was ever working before...

once this is merged, we'll see if the ssh keys are still forwarded to dockerx during image publish :crossed_fingers: 