### PR TITLE
fix: convert blob.subscription into Hamt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3586,6 +3586,7 @@ dependencies = [
  "num-traits",
  "quickcheck",
  "quickcheck_macros",
+ "recall_ipld",
  "recall_sol_facade",
  "serde",
 ]

--- a/fendermint/actors/blobs/shared/Cargo.toml
+++ b/fendermint/actors/blobs/shared/Cargo.toml
@@ -14,7 +14,6 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 anyhow = { workspace = true }
 data-encoding = { workspace = true }
-fendermint_actor_machine = { path = "../../machine" }
 fil_actors_runtime = { workspace = true }
 frc42_dispatch = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
@@ -24,6 +23,7 @@ num-derive = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 
+fendermint_actor_machine = { path = "../../machine" }
 recall_ipld = { path = "../../../../recall/ipld" }
 
 [features]

--- a/fendermint/actors/blobs/shared/src/state.rs
+++ b/fendermint/actors/blobs/shared/src/state.rs
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::collections::HashMap;
+use std::error::Error;
 use std::fmt;
 use std::ops::{Div, Mul};
+use std::str::from_utf8;
 
 use fendermint_actor_machine::util::to_delegated_address;
 use fil_actors_runtime::runtime::Runtime;
@@ -15,9 +17,7 @@ use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
-use recall_ipld::hamt;
-use recall_ipld::hamt::map::TrackedFlushResult;
-use recall_ipld::hamt::MapKey;
+use recall_ipld::{hamt, hamt::map::TrackedFlushResult, hamt::MapKey};
 use serde::{Deserialize, Serialize};
 
 /// Credit is counted the same way as tokens.
@@ -226,18 +226,54 @@ impl From<u64> for Hash {
 pub struct PublicKey(pub [u8; 32]);
 
 /// The stored representation of a blob.
-#[derive(Clone, PartialEq, Debug, Default, Serialize_tuple, Deserialize_tuple)]
+#[derive(Clone, PartialEq, Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct Blob {
     /// The size of the content.
     pub size: u64,
     /// Blob metadata that contains information for blob recovery.
     pub metadata_hash: Hash,
     /// Active subscribers (accounts) that are paying for the blob.
-    pub subscribers: HashMap<String, SubscriptionGroup>,
+    pub subscribers: BlobSubscribers,
     /// Blob status.
     pub status: BlobStatus,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize_tuple, Deserialize_tuple)]
+pub struct BlobSubscribers {
+    pub root: hamt::Root<Address, SubscriptionGroup>,
+    size: u64,
+}
+
+impl BlobSubscribers {
+    pub fn new<BS: Blockstore>(store: &BS) -> Result<Self, ActorError> {
+        let root = hamt::Root::<Address, SubscriptionGroup>::new(store, "blob-subscribers")?;
+        Ok(Self { root, size: 0 })
+    }
+
+    pub fn hamt<BS: Blockstore>(
+        &self,
+        store: BS,
+    ) -> Result<hamt::map::Hamt<BS, Address, SubscriptionGroup>, ActorError> {
+        self.root.hamt(store, self.size)
+    }
+
+    pub fn save_tracked(
+        &mut self,
+        tracked_flush_result: TrackedFlushResult<Address, SubscriptionGroup>,
+    ) {
+        self.root = tracked_flush_result.root;
+        self.size = tracked_flush_result.size;
+    }
+
+    pub fn len(&self) -> u64 {
+        self.size
+    }
+
+    // This is demanded by clippy, https://rust-lang.github.io/rust-clippy/master/index.html#len_without_is_empty.
+    pub fn is_empty(&self) -> bool {
+        self.size == 0
+    }
+}
 /// An object used to determine what [`Account`](s) are accountable for a blob, and for how long.
 /// Subscriptions allow us to distribute the cost of a blob across multiple accounts that
 /// have added the same blob.   
@@ -298,25 +334,64 @@ impl fmt::Display for SubscriptionId {
     }
 }
 
-/// A group of subscriptions for the same subscriber.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(transparent)]
+#[derive(Debug, Clone, PartialEq, Serialize_tuple, Deserialize_tuple)]
 pub struct SubscriptionGroup {
-    /// Subscription group keys.
-    pub subscriptions: HashMap<String, Subscription>,
+    /// Subscription group hamt, keyed by a string representation of SubscriptionId.
+    pub root: hamt::Root<String, Subscription>,
+    size: u64,
+}
+
+// TODO: is works well afaict, but is it a ok/good/reasonable pattern in Rust?
+fn sub_illegal_state_err_map<E>(e: E, sub_id: &SubscriptionId) -> ActorError
+where
+    E: Error,
+{
+    ActorError::illegal_state(format!(
+        "subscriptions for id {} cannot be iterated over: {}",
+        sub_id, e
+    ))
 }
 
 impl SubscriptionGroup {
+    pub fn new<BS: Blockstore>(store: &BS) -> Result<Self, ActorError> {
+        let root = hamt::Root::<String, Subscription>::new(store, "subscription_group")?;
+        Ok(Self { root, size: 0 })
+    }
+
+    pub fn hamt<BS: Blockstore>(
+        &self,
+        store: BS,
+    ) -> Result<hamt::map::Hamt<BS, String, Subscription>, ActorError> {
+        self.root.hamt(store, self.size)
+    }
+
+    pub fn save_tracked(&mut self, tracked_flush_result: TrackedFlushResult<String, Subscription>) {
+        self.root = tracked_flush_result.root;
+        self.size = tracked_flush_result.size;
+    }
+
+    pub fn len(&self) -> u64 {
+        self.size
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.size == 0
+    }
     /// Returns the current group max expiry and the group max expiry after adding the provided ID
     /// and new value.
-    pub fn max_expiries(
+    pub fn max_expiries<BS: Blockstore>(
         &self,
+        store: &BS,
         target_id: &SubscriptionId,
         new_value: Option<ChainEpoch>,
-    ) -> (Option<ChainEpoch>, Option<ChainEpoch>) {
+    ) -> Result<(Option<ChainEpoch>, Option<ChainEpoch>), ActorError> {
         let mut max = None;
         let mut new_max = None;
-        for (id, sub) in self.subscriptions.iter() {
+        let subscriptions = self.hamt(store)?;
+        for val in subscriptions.iter() {
+            let (id_bytes, sub) = val.map_err(|e| sub_illegal_state_err_map(e, target_id))?;
+            let id = from_utf8(id_bytes).map_err(|e| sub_illegal_state_err_map(e, target_id))?;
+
             if sub.failed {
                 continue;
             }
@@ -338,26 +413,31 @@ impl SubscriptionGroup {
                 new_max = Some(new_value);
             }
         }
-        (max, new_max)
+        Ok((max, new_max))
     }
 
     /// Returns whether the provided ID corresponds to a subscription that has the minimum
     /// added epoch and the next minimum added epoch in the group.
-    pub fn is_min_added(
+    pub fn is_min_added<BS: Blockstore>(
         &self,
+        store: &BS,
         trim_id: &SubscriptionId,
     ) -> anyhow::Result<(bool, Option<ChainEpoch>), ActorError> {
         let tid = trim_id.to_string();
-        let trim = self
-            .subscriptions
-            .get(&tid)
+        let subscriptions = self.hamt(store)?;
+        let trim = subscriptions
+            .get(&tid)?
             .ok_or(ActorError::not_found(format!(
                 "subscription id {} not found",
                 trim_id
             )))?;
+
         let mut next_min = None;
-        for (id, sub) in self.subscriptions.iter() {
-            if sub.failed || *id == tid {
+        for val in subscriptions.iter() {
+            let (id_bytes, sub) = val.map_err(|e| sub_illegal_state_err_map(e, trim_id))?;
+            let id = from_utf8(id_bytes).map_err(|e| sub_illegal_state_err_map(e, trim_id))?;
+
+            if sub.failed || id == tid {
                 continue;
             }
             if sub.added < trim.added {

--- a/fendermint/actors/blobs/src/actor.rs
+++ b/fendermint/actors/blobs/src/actor.rs
@@ -489,10 +489,8 @@ impl BlobsActor {
     ) -> Result<Option<BlobStatus>, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
         let subscriber = to_id_address(rt, params.subscriber, false)?;
-        let status =
-            rt.state::<State>()?
-                .get_blob_status(rt.store(), subscriber, params.hash, params.id);
-        Ok(status)
+        rt.state::<State>()?
+            .get_blob_status(rt.store(), subscriber, params.hash, params.id)
     }
 
     /// Returns a list of [`BlobRequest`]s that are currenlty in the [`BlobStatus::Added`] state.
@@ -1415,7 +1413,6 @@ mod tests {
             Method::AddBlob as u64,
             IpldBlock::serialize_cbor(&add_params).unwrap(),
         );
-        dbg!(result.clone().err());
         assert!(result.is_ok());
         rt.verify();
 

--- a/fendermint/actors/blobs/src/state.rs
+++ b/fendermint/actors/blobs/src/state.rs
@@ -2,13 +2,15 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
+use std::error::Error;
 use std::fmt::Display;
+use std::str::from_utf8;
 
 use fendermint_actor_blobs_shared::params::GetStatsReturn;
 use fendermint_actor_blobs_shared::state::{
-    Account, Blob, BlobStatus, Credit, CreditApproval, GasAllowance, Hash, PublicKey, Subscription,
-    SubscriptionGroup, SubscriptionId, TokenCreditRate, TtlStatus,
+    Account, Blob, BlobStatus, BlobSubscribers, Credit, CreditApproval, GasAllowance, Hash,
+    PublicKey, Subscription, SubscriptionGroup, SubscriptionId, TokenCreditRate, TtlStatus,
 };
 use fendermint_actor_recall_config_shared::RecallConfig;
 use fil_actors_runtime::ActorError;
@@ -689,8 +691,11 @@ impl State {
         // Get or create a new blob
         let mut blobs = self.blobs.hamt(store)?;
         let (sub, blob) = if let Some(mut blob) = blobs.get(&hash)? {
-            let sub = if let Some(group) = blob.subscribers.get_mut(&subscriber.to_string()) {
-                let (group_expiry, new_group_expiry) = group.max_expiries(&id, Some(expiry));
+            let mut subscribers = blob.subscribers.hamt(store)?;
+            let sub = if let Some(mut group) = subscribers.get(&subscriber)? {
+                let mut group_hamt = group.hamt(store)?;
+                let (group_expiry, new_group_expiry) =
+                    group.max_expiries(store, &id, Some(expiry))?;
                 // If the subscriber has been debited after the group's max expiry, we need to
                 // clean up the accounting with a refund.
                 // If the ensure-credit check below fails, the refund won't be saved in the
@@ -729,7 +734,7 @@ impl State {
                     current_epoch,
                     &delegation,
                 )?;
-                if let Some(sub) = group.subscriptions.get_mut(&id.to_string()) {
+                let sub = if let Some(mut sub) = group_hamt.get(&id.to_string())? {
                     // Update expiry index
                     if expiry != sub.expiry {
                         self.expiries.update_index(
@@ -749,7 +754,10 @@ impl State {
                         "updated subscription to blob {} for {} (key: {})",
                         hash, subscriber, id
                     );
-                    sub.clone()
+                    group.save_tracked(
+                        group_hamt.set_and_flush_tracked(&id.to_string(), sub.clone())?,
+                    );
+                    sub
                 } else {
                     // Add new subscription
                     let sub = Subscription {
@@ -759,9 +767,9 @@ impl State {
                         delegate: delegation.as_ref().map(|d| d.origin),
                         failed: false,
                     };
-                    group
-                        .subscriptions
-                        .insert(id.clone().to_string(), sub.clone());
+                    group.save_tracked(
+                        group_hamt.set_and_flush_tracked(&id.to_string(), sub.clone())?,
+                    );
                     debug!(
                         "created new subscription to blob {} for {} (key: {})",
                         hash, subscriber, id
@@ -775,7 +783,12 @@ impl State {
                         vec![ExpiryUpdate::Add(expiry)],
                     )?;
                     sub
-                }
+                };
+
+                blob.subscribers
+                    .save_tracked(subscribers.set_and_flush_tracked(&subscriber, group)?);
+
+                sub
             } else {
                 new_account_capacity = size;
                 // One or more accounts have already committed credit.
@@ -800,11 +813,16 @@ impl State {
                     delegate: delegation.as_ref().map(|d| d.origin),
                     failed: false,
                 };
-                blob.subscribers.insert(
-                    subscriber.to_string(),
-                    SubscriptionGroup {
-                        subscriptions: HashMap::from([(id.clone().to_string(), sub.clone())]),
-                    },
+
+                let mut subscribers = blob.subscribers.hamt(store)?;
+                let mut subscription_group = SubscriptionGroup::new(store)?;
+                let mut subscription_group_hamt = subscription_group.hamt(store)?;
+                subscription_group.save_tracked(
+                    subscription_group_hamt.set_and_flush_tracked(&id.to_string(), sub.clone())?,
+                );
+
+                blob.subscribers.save_tracked(
+                    subscribers.set_and_flush_tracked(&subscriber, subscription_group)?,
                 );
                 debug!(
                     "created new subscription to blob {} for {} (key: {})",
@@ -859,17 +877,26 @@ impl State {
                 delegate: delegation.as_ref().map(|d| d.origin),
                 failed: false,
             };
-            let blob = Blob {
+
+            let blob_subscribers = BlobSubscribers::new(store)?;
+            let mut subscribers = blob_subscribers.hamt(store)?;
+
+            let mut blob = Blob {
                 size: size.to_u64().unwrap(),
                 metadata_hash,
-                subscribers: HashMap::from([(
-                    subscriber.to_string(),
-                    SubscriptionGroup {
-                        subscriptions: HashMap::from([(id.clone().to_string(), sub.clone())]),
-                    },
-                )]),
+                subscribers: blob_subscribers,
                 status: BlobStatus::Added,
             };
+
+            let mut subscription_group = SubscriptionGroup::new(store)?;
+            let mut subscription_group_hamt = subscription_group.hamt(store)?;
+            subscription_group.save_tracked(
+                subscription_group_hamt.set_and_flush_tracked(&id.to_string(), sub.clone())?,
+            );
+
+            blob.subscribers
+                .save_tracked(subscribers.set_and_flush_tracked(&subscriber, subscription_group)?);
+
             debug!("created new blob {}", hash);
             debug!(
                 "created new subscription to blob {} for {} (key: {})",
@@ -983,7 +1010,13 @@ impl State {
             .ok()
             .and_then(|blobs| blobs.get(&hash).ok())
             .flatten()?;
-        if blob.subscribers.contains_key(&subscriber.to_string()) {
+        // If the blob can be loaded here, so should the subscribers. Hence we can error if that isn't the case
+        let subscribers = blob
+            .subscribers
+            .hamt(store)
+            .unwrap_or_else(|e| panic!("Error getting blob status: {}", e));
+
+        if subscribers.contains_key(&subscriber).unwrap() {
             match blob.status {
                 BlobStatus::Added => Some(BlobStatus::Added),
                 BlobStatus::Pending => Some(BlobStatus::Pending),
@@ -992,13 +1025,10 @@ impl State {
                     // The blob state's status may have been finalized as failed by another
                     // subscription.
                     // We need to see if this specific subscription failed.
-                    if let Some(sub) = blob
-                        .subscribers
-                        .get(&subscriber.to_string())
-                        .unwrap() // safe here
-                        .subscriptions
-                        .get(&id.to_string())
-                    {
+                    // TODO: I'm not sure about using all these unwraps. It seems like this function should return a Result<Option...>
+                    let group = subscribers.get(&subscriber).unwrap()?; // safe here
+                    let group_hamt = group.hamt(store).unwrap();
+                    if let Some(sub) = group_hamt.get(&id.to_string()).unwrap() {
                         if sub.failed {
                             Some(BlobStatus::Failed)
                         } else {
@@ -1102,20 +1132,20 @@ impl State {
             // We can ignore later finalizations, even if they are failed.
             return Ok(());
         }
-        let group =
-            blob.subscribers
-                .get_mut(&subscriber.to_string())
-                .ok_or(ActorError::forbidden(format!(
-                    "subscriber {} is not subscribed to blob {}",
-                    subscriber, hash
-                )))?;
+        let mut subscribers = blob.subscribers.hamt(store)?;
+        let mut group = subscribers
+            .get(&subscriber)?
+            .ok_or(ActorError::forbidden(format!(
+                "subscriber {} is not subscribed to blob {}",
+                subscriber, hash
+            )))?;
         // Get max expiries with the current subscription removed in case we need them below.
         // We have to do this here to avoid breaking borrow rules.
-        let (group_expiry, new_group_expiry) = group.max_expiries(&id, Some(0));
-        let (sub_is_min_added, next_min_added) = group.is_min_added(&id)?;
-        let sub = group
-            .subscriptions
-            .get_mut(&id.to_string())
+        let (group_expiry, new_group_expiry) = group.max_expiries(store, &id, Some(0))?;
+        let (sub_is_min_added, next_min_added) = group.is_min_added(store, &id)?;
+        let mut group_hamt = group.hamt(store)?;
+        let mut sub = group_hamt
+            .get(&id.to_string())?
             .ok_or(ActorError::not_found(format!(
                 "subscription id {} not found",
                 id.clone()
@@ -1224,7 +1254,10 @@ impl State {
                 }
                 debug!("released {} credits to {}", reclaim_credits, subscriber);
             }
+
             sub.failed = true;
+            // flush the mutated sub to the group's store
+            group.save_tracked(group_hamt.set_and_flush_tracked(&id.to_string(), sub.clone())?);
         }
         // Remove the source from the pending queue
         self.pending
@@ -1232,9 +1265,13 @@ impl State {
         // Save accounts
         accounts.set(&subscriber, account)?;
         self.accounts.save_tracked(accounts.flush_tracked()?);
+
+        blob.subscribers
+            .save_tracked(subscribers.set_and_flush_tracked(&subscriber, group)?);
         // Save blob
         self.blobs
             .save_tracked(blobs.set_and_flush_tracked(&hash, blob)?);
+
         Ok(())
     }
 
@@ -1265,18 +1302,18 @@ impl State {
             // We could use a custom error code, but this is easier.
             return Ok((false, 0));
         };
+        let mut subscribers = blob.subscribers.hamt(store)?;
         let num_subscribers = blob.subscribers.len();
-        let group =
-            blob.subscribers
-                .get_mut(&subscriber.to_string())
-                .ok_or(ActorError::forbidden(format!(
-                    "subscriber {} is not subscribed to blob {}",
-                    subscriber, hash
-                )))?;
-        let (group_expiry, new_group_expiry) = group.max_expiries(&id, Some(0));
-        let sub = group
-            .subscriptions
-            .get(&id.to_string())
+        let mut group = subscribers
+            .get(&subscriber)?
+            .ok_or(ActorError::forbidden(format!(
+                "subscriber {} is not subscribed to blob {}",
+                subscriber, hash
+            )))?;
+        let mut group_hamt = group.hamt(store)?;
+        let (group_expiry, new_group_expiry) = group.max_expiries(store, &id, Some(0))?;
+        let sub = group_hamt
+            .get(&id.to_string())?
             .ok_or(ActorError::not_found(format!(
                 "subscription id {} not found",
                 id.clone()
@@ -1450,17 +1487,19 @@ impl State {
         self.pending
             .remove_source(store, hash, (subscriber, id.clone(), sub.source), size)?;
         // Delete subscription
-        group.subscriptions.remove(&id.to_string());
+        let (sub_del_flush, _) = group_hamt.delete_and_flush_tracked(&id.to_string())?;
+        group.save_tracked(sub_del_flush);
         debug!(
             "deleted subscription to blob {} for {} (key: {})",
             hash, subscriber, id
         );
         // Delete the group if empty
-        let delete_blob = if group.subscriptions.is_empty() {
-            blob.subscribers.remove(&subscriber.to_string());
+        let delete_blob = if group.is_empty() {
+            let (del_sub, _) = subscribers.delete_and_flush_tracked(&subscriber)?;
+            blob.subscribers.save_tracked(del_sub);
             debug!("deleted subscriber {} to blob {}", subscriber, hash);
             // Delete or update blob
-            let delete_blob = blob.subscribers.is_empty();
+            let delete_blob = subscribers.is_empty();
             if delete_blob {
                 let (res, _) = blobs.delete_and_flush_tracked(&hash)?;
                 self.blobs.save_tracked(res);
@@ -1468,6 +1507,8 @@ impl State {
             }
             delete_blob
         } else {
+            blob.subscribers
+                .save_tracked(subscribers.set_and_flush_tracked(&subscriber, group)?);
             self.blobs
                 .save_tracked(blobs.set_and_flush_tracked(&hash, blob)?);
             false
@@ -1507,12 +1548,28 @@ impl State {
         let mut processed = 0;
         let blobs = self.blobs.hamt(store)?;
         let starting_key = starting_hash.map(|h| BytesKey::from(h.0.as_slice()));
+
+        fn err_map<E>(e: E) -> ActorError
+        where
+            E: Error,
+        {
+            ActorError::illegal_state(format!(
+                "subscriptions group cannot be iterated over: {}",
+                e
+            ))
+        }
+
         let (_, next_key) = blobs.for_each_ranged(
             starting_key.as_ref(),
             limit,
             |hash, blob| -> Result<(), ActorError> {
-                if let Some(group) = blob.subscribers.get(&subscriber.to_string()) {
-                    for (id, sub) in &group.subscriptions {
+                let subscribers = blob.subscribers.hamt(store)?;
+                if let Some(group) = subscribers.get(&subscriber)? {
+                    let group_hamt = group.hamt(store)?;
+                    for val in group_hamt.iter() {
+                        let (id_bytes, sub) = val.map_err(err_map)?;
+                        let id = from_utf8(id_bytes).map_err(err_map)?;
+
                         if sub.expiry - sub.added > new_ttl {
                             if new_ttl == 0 {
                                 // Delete subscription
@@ -1522,7 +1579,7 @@ impl State {
                                     subscriber,
                                     current_epoch,
                                     hash,
-                                    SubscriptionId::new(&id.clone())?,
+                                    SubscriptionId::new(id)?,
                                 )?;
                                 if from_disc {
                                     deleted_blobs.push(hash);
@@ -1536,7 +1593,7 @@ impl State {
                                     current_epoch,
                                     hash,
                                     blob.metadata_hash,
-                                    SubscriptionId::new(&id.clone())?,
+                                    SubscriptionId::new(id)?,
                                     blob.size,
                                     Some(new_ttl),
                                     sub.source,
@@ -1744,7 +1801,7 @@ mod tests {
     use fvm_ipld_blockstore::MemoryBlockstore;
     use rand::seq::SliceRandom;
     use rand::Rng;
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, HashMap};
     use std::ops::{AddAssign, SubAssign};
 
     fn check_approval_used<BS: Blockstore>(
@@ -2301,8 +2358,9 @@ mod tests {
 
         // Check the subscription group
         let blob = state.get_blob(&store, hash).unwrap().unwrap();
-        let group = blob.subscribers.get(&subscriber.to_string()).unwrap();
-        assert_eq!(group.subscriptions.len(), 2);
+        let subscribers = blob.subscribers.hamt(store).unwrap();
+        let group = subscribers.get(&subscriber).unwrap().unwrap();
+        assert_eq!(group.len(), 2);
 
         // Debit all accounts at an epoch between the two expiries (3601-3621)
         let debit_epoch = ChainEpoch::from(config.blob_min_ttl + 11);
@@ -2328,8 +2386,9 @@ mod tests {
 
         // Check the subscription group
         let blob = state.get_blob(&store, hash).unwrap().unwrap();
-        let group = blob.subscribers.get(&subscriber.to_string()).unwrap();
-        assert_eq!(group.subscriptions.len(), 1); // the first subscription was deleted
+        let subscribers = blob.subscribers.hamt(&store).unwrap();
+        let group = subscribers.get(&subscriber).unwrap().unwrap();
+        assert_eq!(group.len(), 1); // the first subscription was deleted
 
         // Debit all accounts at an epoch greater than group expiry (3621)
         let debit_epoch = ChainEpoch::from(config.blob_min_ttl + 31);
@@ -2757,15 +2816,17 @@ mod tests {
 
         // Check the blob
         let blob = state.get_blob(&store, hash).unwrap().unwrap();
+        let subscribers = blob.subscribers.hamt(store).unwrap();
         assert_eq!(blob.subscribers.len(), 1);
         assert_eq!(blob.status, BlobStatus::Added);
         assert_eq!(blob.size, size);
 
         // Check the subscription group
-        let group = blob.subscribers.get(&subscriber.to_string()).unwrap();
-        assert_eq!(group.subscriptions.len(), 1);
-        let got_sub = group.subscriptions.get(&id1.clone().to_string()).unwrap();
-        assert_eq!(*got_sub, sub);
+        let group = subscribers.get(&subscriber).unwrap().unwrap();
+        let group_hamt = group.hamt(store).unwrap();
+        assert_eq!(group.len(), 1);
+        let got_sub = group_hamt.get(&id1.clone().to_string()).unwrap().unwrap();
+        assert_eq!(got_sub, sub);
 
         // Check the account balance
         let account = state.get_account(&store, subscriber).unwrap().unwrap();
@@ -2851,15 +2912,17 @@ mod tests {
 
         // Check the blob
         let blob = state.get_blob(&store, hash).unwrap().unwrap();
+        let subscribers = blob.subscribers.hamt(store).unwrap();
         assert_eq!(blob.subscribers.len(), 1);
         assert_eq!(blob.status, BlobStatus::Resolved);
         assert_eq!(blob.size, size);
 
         // Check the subscription group
-        let group = blob.subscribers.get(&subscriber.to_string()).unwrap();
-        assert_eq!(group.subscriptions.len(), 1); // Still only one subscription
-        let got_sub = group.subscriptions.get(&id1.clone().to_string()).unwrap();
-        assert_eq!(*got_sub, sub);
+        let group = subscribers.get(&subscriber).unwrap().unwrap();
+        let group_hamt = group.hamt(store).unwrap();
+        assert_eq!(group.len(), 1); // Still only one subscription
+        let got_sub = group_hamt.get(&id1.clone().to_string()).unwrap().unwrap();
+        assert_eq!(got_sub, sub);
 
         // Check the account balance
         let account = state.get_account(&store, subscriber).unwrap().unwrap();
@@ -2917,15 +2980,17 @@ mod tests {
 
         // Check the blob
         let blob = state.get_blob(&store, hash).unwrap().unwrap();
+        let subscribers = blob.subscribers.hamt(store).unwrap();
         assert_eq!(blob.subscribers.len(), 1); // still only one subscriber
         assert_eq!(blob.status, BlobStatus::Resolved);
         assert_eq!(blob.size, size);
 
         // Check the subscription group
-        let group = blob.subscribers.get(&subscriber.to_string()).unwrap();
-        assert_eq!(group.subscriptions.len(), 2);
-        let got_sub = group.subscriptions.get(&id2.clone().to_string()).unwrap();
-        assert_eq!(*got_sub, sub);
+        let group = subscribers.get(&subscriber).unwrap().unwrap();
+        let group_hamt = group.hamt(store).unwrap();
+        assert_eq!(group.len(), 2);
+        let got_sub = group_hamt.get(&id2.clone().to_string()).unwrap().unwrap();
+        assert_eq!(got_sub, sub);
 
         // Check the account balance
         let account = state.get_account(&store, subscriber).unwrap().unwrap();
@@ -2968,6 +3033,7 @@ mod tests {
         // Delete the default subscription ID
         let delete_epoch = ChainEpoch::from(51);
         let res = state.delete_blob(&store, origin, subscriber, delete_epoch, hash, id1.clone());
+
         assert!(res.is_ok());
         let (delete_from_disk, deleted_size) = res.unwrap();
         assert!(!delete_from_disk);
@@ -2975,14 +3041,17 @@ mod tests {
 
         // Check the blob
         let blob = state.get_blob(&store, hash).unwrap().unwrap();
+        let subscribers = blob.subscribers.hamt(store).unwrap();
+
         assert_eq!(blob.subscribers.len(), 1); // still one subscriber
         assert_eq!(blob.status, BlobStatus::Resolved);
         assert_eq!(blob.size, size);
 
         // Check the subscription group
-        let group = blob.subscribers.get(&subscriber.to_string()).unwrap();
-        assert_eq!(group.subscriptions.len(), 1);
-        let sub = group.subscriptions.get(&id2.clone().to_string()).unwrap();
+        let group = subscribers.get(&subscriber).unwrap().unwrap();
+        let group_hamt = group.hamt(store).unwrap();
+        assert_eq!(group.len(), 1);
+        let sub = group_hamt.get(&id2.clone().to_string()).unwrap().unwrap();
         assert_eq!(sub.added, add3_epoch);
         assert_eq!(sub.expiry, add3_epoch + config.blob_min_ttl);
 
@@ -3748,16 +3817,22 @@ mod tests {
                 let res = state.get_blob(&store, hash);
                 assert!(res.is_ok(), "Failed to get blob: {:?}", res.err());
                 let blob = res.unwrap().unwrap();
-                for (_, group) in blob.subscribers {
-                    for (_, sub) in group.subscriptions {
-                        assert_eq!(
-                            sub.expiry,
-                            current_epoch + tc.expected_blob_ttl,
-                            "Test case '{}' has unexpected blob expiry",
-                            tc.name
-                        );
-                    }
-                }
+                let subscribers = blob.subscribers.hamt(&store).unwrap();
+                subscribers
+                    .for_each(|_, group| {
+                        let group_hamt = group.hamt(&store).unwrap();
+                        for val in group_hamt.iter() {
+                            let (_, sub) = val.unwrap();
+                            assert_eq!(
+                                sub.expiry,
+                                current_epoch + tc.expected_blob_ttl,
+                                "Test case '{}' has unexpected blob expiry",
+                                tc.name
+                            );
+                        }
+                        Ok(())
+                    })
+                    .unwrap();
             } else {
                 assert!(
                     res.is_err(),
@@ -4006,8 +4081,10 @@ mod tests {
                     );
                 } else {
                     let blob = state.get_blob(&store, *hash).unwrap().unwrap();
-                    let group = blob.subscribers.get(&addr.to_string()).unwrap();
-                    let sub = group.subscriptions.get(&format!("blob-{}", i)).unwrap();
+                    let subscribers = blob.subscribers.hamt(&store).unwrap();
+                    let group = subscribers.get(&addr).unwrap().unwrap();
+                    let group_hamt = group.hamt(&store).unwrap();
+                    let sub = group_hamt.get(&format!("blob-{}", i)).unwrap().unwrap();
 
                     assert_eq!(
                         sub.expiry - sub.added,

--- a/fendermint/actors/bucket/Cargo.toml
+++ b/fendermint/actors/bucket/Cargo.toml
@@ -28,6 +28,7 @@ serde = { workspace = true, features = ["derive"] }
 
 fendermint_actor_blobs_shared = { path = "../blobs/shared" }
 fendermint_actor_machine = { path = "../machine" }
+recall_ipld = { path = "../../../recall/ipld" }
 
 [dev-dependencies]
 fil_actors_evm_shared = { workspace = true }

--- a/fendermint/actors/bucket/src/actor.rs
+++ b/fendermint/actors/bucket/src/actor.rs
@@ -905,7 +905,7 @@ mod tests {
         group.save_tracked(
             group_hamt
                 .set_and_flush_tracked(
-                    &sub_id.to_string(),
+                    &sub_id,
                     Subscription {
                         added: 0,
                         expiry: ChainEpoch::from(3600),
@@ -1143,7 +1143,7 @@ mod tests {
         group.save_tracked(
             group_hamt
                 .set_and_flush_tracked(
-                    &sub_id.to_string(),
+                    &sub_id,
                     Subscription {
                         added: 0,
                         expiry: ChainEpoch::from(3600),

--- a/fendermint/actors/bucket/src/actor.rs
+++ b/fendermint/actors/bucket/src/actor.rs
@@ -18,6 +18,7 @@ use fil_actors_runtime::{
     runtime::{ActorCode, Runtime},
     ActorError,
 };
+use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_hamt::BytesKey;
 use fvm_shared::address::Address;
 use recall_sol_facade::bucket::{object_added, object_deleted, object_metadata_updated};
@@ -159,7 +160,7 @@ impl Actor {
         let key = BytesKey(params.0);
         if let Some(object_state) = state.get(rt.store(), &key)? {
             if let Some(blob) = get_blob(rt, object_state.hash)? {
-                let object = build_object(&blob, &object_state, sub_id, owner)?;
+                let object = build_object(rt.store(), &blob, &object_state, sub_id, owner)?;
                 Ok(object)
             } else {
                 Ok(None)
@@ -279,7 +280,8 @@ fn get_blob_id(state: &State, key: &[u8]) -> anyhow::Result<SubscriptionId, Acto
 }
 
 /// Build an object from its state and blob.
-fn build_object(
+fn build_object<BS: Blockstore>(
+    store: &BS,
     blob: &Blob,
     object_state: &ObjectState,
     sub_id: SubscriptionId,
@@ -287,16 +289,14 @@ fn build_object(
 ) -> anyhow::Result<Option<Object>, ActorError> {
     match blob.status {
         BlobStatus::Resolved => {
-            let group = blob
-                .subscribers
-                .get(&subscriber.to_string())
-                .ok_or_else(|| {
-                    ActorError::illegal_state(format!(
-                        "owner {} is not subscribed to blob {}; this should not happen",
-                        subscriber, object_state.hash
-                    ))
-                })?;
-            let (expiry, _) = group.max_expiries(&sub_id, None);
+            let subscribers = blob.subscribers.hamt(store)?;
+            let group = subscribers.get(&subscriber)?.ok_or_else(|| {
+                ActorError::illegal_state(format!(
+                    "owner {} is not subscribed to blob {}; this should not happen",
+                    subscriber, object_state.hash
+                ))
+            })?;
+            let (expiry, _) = group.max_expiries(store, &sub_id, None)?;
             if let Some(expiry) = expiry {
                 Ok(Some(Object {
                     hash: object_state.hash,
@@ -401,12 +401,13 @@ mod tests {
             AddBlobParams, DeleteBlobParams, GetBlobParams, GetCreditApprovalParams,
             OverwriteBlobParams,
         },
-        state::{CreditApproval, Hash, Subscription, SubscriptionGroup},
+        state::{BlobSubscribers, CreditApproval, Hash, Subscription, SubscriptionGroup},
         Method as BlobMethod, BLOBS_ACTOR_ADDR,
     };
     use fendermint_actor_blobs_testing::{new_hash, new_pk, setup_logs};
     use fendermint_actor_machine::{events::to_actor_event, ConstructorParams, InitParams, Kind};
     use fil_actors_evm_shared::address::EthAddress;
+    use fil_actors_runtime::runtime::Runtime;
     use fil_actors_runtime::test_utils::{
         expect_empty, MockRuntime, ADM_ACTOR_CODE_ID, ETHACCOUNT_ACTOR_CODE_ID, INIT_ACTOR_CODE_ID,
     };
@@ -885,27 +886,40 @@ mod tests {
         .unwrap();
         rt.verify();
 
+        let store = rt.store();
+        let blob_subscribers = BlobSubscribers::new(store).unwrap();
+
+        let mut subscribers = blob_subscribers.hamt(store).unwrap();
+
         // Get the object
-        let blob = Blob {
+        let mut blob = Blob {
             size: add_params.size,
-            subscribers: HashMap::from([(
-                origin.to_string(),
-                SubscriptionGroup {
-                    subscriptions: HashMap::from([(
-                        sub_id.to_string(),
-                        Subscription {
-                            added: 0,
-                            expiry: ttl,
-                            source: add_params.source,
-                            delegate: Some(origin),
-                            failed: false,
-                        },
-                    )]),
-                },
-            )]),
+            subscribers: blob_subscribers,
             status: BlobStatus::Resolved,
             metadata_hash: add_params.recovery_hash,
         };
+
+        let mut group = SubscriptionGroup::new(store).unwrap();
+        let mut group_hamt = group.hamt(store).unwrap();
+
+        group.save_tracked(
+            group_hamt
+                .set_and_flush_tracked(
+                    &sub_id.to_string(),
+                    Subscription {
+                        added: 0,
+                        expiry: ChainEpoch::from(3600),
+                        source: add_params.source,
+                        delegate: Some(origin),
+                        failed: false,
+                    },
+                )
+                .unwrap(),
+        );
+
+        blob.subscribers
+            .save_tracked(subscribers.set_and_flush_tracked(&origin, group).unwrap());
+
         rt.expect_validate_caller_any();
         rt.expect_send(
             BLOBS_ACTOR_ADDR,
@@ -1111,27 +1125,39 @@ mod tests {
         rt.verify();
 
         // Get the object and check metadata
+        let store = rt.store();
+        let blob_subscribers = BlobSubscribers::new(store).unwrap();
+        let mut subscribers = blob_subscribers.hamt(store).unwrap();
+
         let sub_id = get_blob_id(&state, &key).unwrap();
-        let blob = Blob {
+        let mut blob = Blob {
             size: add_params.size,
-            subscribers: HashMap::from([(
-                origin.to_string(),
-                SubscriptionGroup {
-                    subscriptions: HashMap::from([(
-                        sub_id.to_string(),
-                        Subscription {
-                            added: 0,
-                            expiry: ChainEpoch::from(3600),
-                            source: add_params.source,
-                            delegate: Some(origin),
-                            failed: false,
-                        },
-                    )]),
-                },
-            )]),
+            subscribers: blob_subscribers,
             status: BlobStatus::Resolved,
             metadata_hash: add_params.recovery_hash,
         };
+
+        let mut group = SubscriptionGroup::new(store).unwrap();
+        let mut group_hamt = group.hamt(store).unwrap();
+
+        group.save_tracked(
+            group_hamt
+                .set_and_flush_tracked(
+                    &sub_id.to_string(),
+                    Subscription {
+                        added: 0,
+                        expiry: ChainEpoch::from(3600),
+                        source: add_params.source,
+                        delegate: Some(origin),
+                        failed: false,
+                    },
+                )
+                .unwrap(),
+        );
+
+        blob.subscribers
+            .save_tracked(subscribers.set_and_flush_tracked(&origin, group).unwrap());
+
         rt.expect_validate_caller_any();
         rt.expect_send(
             BLOBS_ACTOR_ADDR,

--- a/recall/ipld/src/hamt.rs
+++ b/recall/ipld/src/hamt.rs
@@ -7,5 +7,5 @@ mod core;
 pub mod map;
 
 pub use core::MapKey;
-pub use fvm_ipld_hamt::BytesKey;
+pub use fvm_ipld_hamt::{BytesKey, Error};
 pub use map::Root;

--- a/recall/ipld/src/hamt/core.rs
+++ b/recall/ipld/src/hamt/core.rs
@@ -11,6 +11,7 @@ use cid::Cid;
 use fil_actors_runtime::{ActorError, AsActorError};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_hamt as hamt;
+use fvm_ipld_hamt::{BytesKey, Iter};
 use fvm_shared::address::Address;
 use fvm_shared::error::ExitCode;
 use integer_encoding::VarInt;
@@ -253,6 +254,11 @@ where
         Ok(())
     }
 
+    /// Return an Iter of the key-value pairs in the map.
+    pub fn iter(&self) -> Iter<BS, V, BytesKey> {
+        self.hamt.iter()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.hamt.is_empty()
     }
@@ -281,6 +287,22 @@ impl MapKey for Vec<u8> {
 
     fn to_bytes(&self) -> Result<Vec<u8>, String> {
         Ok(self.clone())
+    }
+}
+
+impl MapKey for String {
+    fn from_bytes(b: &[u8]) -> Result<Self, String> {
+        let result = String::from_utf8(b.to_vec());
+
+        if result.is_ok() {
+            Ok(result.unwrap())
+        } else {
+            Err(format!("failed to decode varint in {:?}", b))
+        }
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>, String> {
+        Ok(self.as_bytes().to_vec())
     }
 }
 

--- a/recall/ipld/src/hamt/core.rs
+++ b/recall/ipld/src/hamt/core.rs
@@ -11,7 +11,6 @@ use cid::Cid;
 use fil_actors_runtime::{ActorError, AsActorError};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_hamt as hamt;
-use fvm_ipld_hamt::{BytesKey, Iter};
 use fvm_shared::address::Address;
 use fvm_shared::error::ExitCode;
 use integer_encoding::VarInt;
@@ -254,8 +253,7 @@ where
         Ok(())
     }
 
-    /// Return an Iter of the key-value pairs in the map.
-    pub fn iter(&self) -> Iter<BS, V, BytesKey> {
+    pub fn iter(&self) -> hamt::Iter<BS, V, hamt::BytesKey, Hasher> {
         self.hamt.iter()
     }
 
@@ -292,13 +290,7 @@ impl MapKey for Vec<u8> {
 
 impl MapKey for String {
     fn from_bytes(b: &[u8]) -> Result<Self, String> {
-        let result = String::from_utf8(b.to_vec());
-
-        if result.is_ok() {
-            Ok(result.unwrap())
-        } else {
-            Err(format!("failed to decode varint in {:?}", b))
-        }
+        String::from_utf8(b.to_vec()).map_err(|e| e.to_string())
     }
 
     fn to_bytes(&self) -> Result<Vec<u8>, String> {

--- a/recall/ipld/src/hamt/map.rs
+++ b/recall/ipld/src/hamt/map.rs
@@ -15,6 +15,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use super::core::{Map, MapKey, DEFAULT_HAMT_CONFIG};
+use crate::Hasher;
 
 #[derive(Clone, PartialEq, Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct Root<K, V>
@@ -232,7 +233,7 @@ where
         self.map.for_each_until(starting_key, ending_key, &mut f)
     }
 
-    pub fn iter(&self) -> Iter<BS, V, BytesKey> {
+    pub fn iter(&self) -> Iter<BS, V, BytesKey, Hasher> {
         self.map.iter()
     }
 }

--- a/recall/ipld/src/hamt/map.rs
+++ b/recall/ipld/src/hamt/map.rs
@@ -10,7 +10,7 @@ use cid::Cid;
 use fil_actors_runtime::ActorError;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_hamt::BytesKey;
+use fvm_ipld_hamt::{BytesKey, Iter};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -230,5 +230,9 @@ where
         F: FnMut(K, &V) -> Result<(), ActorError>,
     {
         self.map.for_each_until(starting_key, ending_key, &mut f)
+    }
+
+    pub fn iter(&self) -> Iter<BS, V, BytesKey> {
+        self.map.iter()
     }
 }


### PR DESCRIPTION
## Overview
The `Blob` stuct was an ipld hamt that contained a HashMap of its `Subcribers`, which contained a HashMap of `SubscriptionGroups`.  These nested hash maps had the potential to grow larger than can be flushed to the blockstore (1MB).
This change converts the nested hash maps into nested hamts, hence preventing issues with exceeding the 1MB limit

## Details 
This change include a lot of conversion of hash map to hamt while maintaining logic.  The majority of this is working through when to flush the inner hamts and converting from `Option` to `Result`.  It also includes some additions to the hamt implementation.  A hamt now has an `iter` method so it can be used in for loops, and the hamt can now be keyed with a `String`, which is what the subscription groups are keyed with. 

fixes #441 
