### PR TITLE
perf: paginate account credit debits

### DIFF
--- a/fendermint/actors/blobs/src/actor.rs
+++ b/fendermint/actors/blobs/src/actor.rs
@@ -385,10 +385,8 @@ impl BlobsActor {
     /// This is called by the system actor every X blocks, where X is set in the recall config actor.
     /// TODO: Take a start key and page limit to avoid out-of-gas errors.
     fn debit_accounts(rt: &impl Runtime) -> Result<(), ActorError> {
-        // rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
-        rt.validate_immediate_caller_accept_any()?;
+        rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
         let config = get_config(rt)?;
-
         let mut credit_debited = Credit::zero();
         let (deletes, num_accounts) = rt.transaction(|st: &mut State, rt| {
             let initial_credit_debited = st.credit_debited.clone();
@@ -1375,12 +1373,6 @@ mod tests {
         assert!(result.is_ok());
         rt.verify();
 
-        // After funding the account, commit credits for storage
-        rt.set_caller(*ETHACCOUNT_ACTOR_CODE_ID, id_addr);
-        rt.expect_validate_caller_any();
-        expect_get_config(&rt);
-
-        // Then add blobs...
         rt.set_epoch(ChainEpoch::from(5));
         rt.expect_validate_caller_any();
         expect_get_config(&rt);

--- a/fendermint/actors/blobs/src/actor.rs
+++ b/fendermint/actors/blobs/src/actor.rs
@@ -1104,6 +1104,7 @@ mod tests {
         rt.set_caller(*EVM_ACTOR_CODE_ID, proxy_id_addr);
         rt.set_origin(owner_id_addr);
         rt.expect_validate_caller_any();
+        expect_get_config(&rt);
         let approve_params = ApproveCreditParams {
             from: owner_id_addr,
             to: to_id_addr,
@@ -1373,6 +1374,7 @@ mod tests {
         assert!(result.is_ok());
         rt.verify();
 
+        // Try with sufficient balance
         rt.set_epoch(ChainEpoch::from(5));
         rt.expect_validate_caller_any();
         expect_get_config(&rt);

--- a/fendermint/actors/blobs/src/state.rs
+++ b/fendermint/actors/blobs/src/state.rs
@@ -544,10 +544,9 @@ impl State {
         let reader = self.accounts.hamt(store)?;
         let mut writer = self.accounts.hamt(store)?;
 
-        let start_key = match self.next_debit_addr {
-            Some(address) => Some(BytesKey::from(address.to_bytes())),
-            None => None,
-        };
+        let start_key = self
+            .next_debit_addr
+            .map(|address| BytesKey::from(address.to_bytes()));
         let batch_size = Some(5);
         let (count, next_account) =
             reader.for_each_ranged(start_key.as_ref(), batch_size, |address, account| {

--- a/fendermint/actors/blobs/src/state.rs
+++ b/fendermint/actors/blobs/src/state.rs
@@ -528,7 +528,7 @@ impl State {
                     key.hash,
                     key.id.clone(),
                 ) {
-                    Ok(from_disc) => {
+                    Ok((from_disc, _)) => {
                         num_deleted += 1;
                         if from_disc {
                             delete_from_disc.insert(key.hash);

--- a/fendermint/actors/blobs/src/state/expiries.rs
+++ b/fendermint/actors/blobs/src/state/expiries.rs
@@ -88,7 +88,7 @@ impl ExpiriesState {
                 Ok(true)
             },
         )?;
-        self.next_idx = batch_size.and_then(|_| next_idx);
+        self.next_idx = batch_size.and(next_idx);
         Ok(())
     }
 

--- a/fendermint/actors/blobs/src/state/expiries.rs
+++ b/fendermint/actors/blobs/src/state/expiries.rs
@@ -73,7 +73,7 @@ impl ExpiriesState {
         F: FnMut(ChainEpoch, Address, ExpiryKey) -> Result<(), ActorError>,
     {
         let expiries = self.amt(&store)?;
-        let (_, next_idx) = expiries.for_each_while_ranged(
+        let (count, next_idx) = expiries.for_each_while_ranged(
             self.next_idx,
             batch_size,
             |index, per_chain_epoch_root| {
@@ -89,6 +89,11 @@ impl ExpiriesState {
             },
         )?;
         self.next_idx = batch_size.and(next_idx);
+        log::debug!(
+            "finished deleting expired blobs up to epoch: {}, count: {}",
+            epoch,
+            count
+        );
         Ok(())
     }
 

--- a/fendermint/actors/blobs/src/state/expiries.rs
+++ b/fendermint/actors/blobs/src/state/expiries.rs
@@ -89,10 +89,11 @@ impl ExpiriesState {
             },
         )?;
         self.next_idx = batch_size.and(next_idx);
-        log::debug!(
-            "finished deleting expired blobs up to epoch: {}, count: {}",
-            epoch,
-            count
+        log::info!(
+            "finished deleting {} blobs, next_idx: {:?}, current_epoch: {}",
+            count,
+            self.next_idx,
+            epoch
         );
         Ok(())
     }

--- a/fendermint/actors/blobs/src/state/expiries.rs
+++ b/fendermint/actors/blobs/src/state/expiries.rs
@@ -19,6 +19,7 @@ type PerChainEpochRoot = hamt::Root<Address, hamt::Root<ExpiryKey, ()>>;
 #[derive(Debug, Clone, Serialize_tuple, Deserialize_tuple)]
 pub struct ExpiriesState {
     pub root: amt::Root<PerChainEpochRoot>,
+    pub next_idx: Option<u64>,
 }
 
 impl ExpiriesState {
@@ -40,7 +41,10 @@ impl ExpiriesState {
 
     pub fn new<BS: Blockstore>(store: &BS) -> Result<Self, ActorError> {
         let root = amt::Root::<PerChainEpochRoot>::new(store)?;
-        Ok(Self { root })
+        Ok(Self {
+            root,
+            next_idx: None,
+        })
     }
 
     pub fn amt<BS: Blockstore>(
@@ -59,26 +63,32 @@ impl ExpiriesState {
     }
 
     pub fn foreach_up_to_epoch<BS: Blockstore, F>(
-        &self,
+        &mut self,
         store: BS,
         epoch: ChainEpoch,
+        batch_size: Option<u64>,
         mut f: F,
     ) -> Result<(), ActorError>
     where
         F: FnMut(ChainEpoch, Address, ExpiryKey) -> Result<(), ActorError>,
     {
         let expiries = self.amt(&store)?;
-        expiries.for_each_while_ranged(None, None, |index, per_chain_epoch_root| {
-            if index > epoch as u64 {
-                return Ok(false);
-            }
-            let per_chain_epoch_hamt = per_chain_epoch_root.hamt(&store, 0)?; // The size is not important here
-            per_chain_epoch_hamt.for_each(|address, per_address_root| {
-                let per_address_hamt = per_address_root.hamt(&store, 0)?; // The size is not important here
-                per_address_hamt.for_each(|expiry_key, _| f(index as i64, address, expiry_key))
-            })?;
-            Ok(true)
-        })?;
+        let (_, next_idx) = expiries.for_each_while_ranged(
+            self.next_idx,
+            batch_size,
+            |index, per_chain_epoch_root| {
+                if index > epoch as u64 {
+                    return Ok(false);
+                }
+                let per_chain_epoch_hamt = per_chain_epoch_root.hamt(&store, 0)?;
+                per_chain_epoch_hamt.for_each(|address, per_address_root| {
+                    let per_address_hamt = per_address_root.hamt(&store, 0)?;
+                    per_address_hamt.for_each(|expiry_key, _| f(index as i64, address, expiry_key))
+                })?;
+                Ok(true)
+            },
+        )?;
+        self.next_idx = batch_size.and_then(|_| next_idx);
         Ok(())
     }
 
@@ -182,14 +192,13 @@ mod tests {
         let mut hashes = vec![];
         for i in 1..=100 {
             let (hash, _) = new_hash(1024);
-            let expiry = ChainEpoch::from(i);
             state
                 .update_index(
                     &store,
                     addr,
                     hash,
                     &SubscriptionId::default(),
-                    vec![ExpiryUpdate::Add(expiry)],
+                    vec![ExpiryUpdate::Add(i)],
                 )
                 .unwrap();
             hashes.push(hash);
@@ -198,7 +207,7 @@ mod tests {
 
         let mut range = vec![];
         state
-            .foreach_up_to_epoch(&store, 10, |chain_epoch, _, _| {
+            .foreach_up_to_epoch(&store, 10, None, |chain_epoch, _, _| {
                 range.push(chain_epoch);
                 Ok(())
             })
@@ -221,11 +230,275 @@ mod tests {
 
         let mut range = vec![];
         state
-            .foreach_up_to_epoch(&store, 10, |chain_epoch, _, _| {
+            .foreach_up_to_epoch(&store, 10, None, |chain_epoch, _, _| {
                 range.push(chain_epoch);
                 Ok(())
             })
             .unwrap();
         assert_eq!(range.len(), 9);
+    }
+
+    #[test]
+    fn test_expiries_pagination() {
+        let store = MemoryBlockstore::default();
+        let mut state = ExpiriesState::new(&store).unwrap();
+        let addr = new_address();
+
+        // Create expiries at epochs 1,2,4,7,8,10
+        for i in &[1, 2, 4, 7, 8, 10] {
+            let (hash, _) = new_hash(1024);
+            state
+                .update_index(
+                    &store,
+                    addr,
+                    hash,
+                    &SubscriptionId::default(),
+                    vec![ExpiryUpdate::Add(*i as ChainEpoch)],
+                )
+                .unwrap();
+        }
+
+        // Process with batch size 2
+        let mut processed = vec![];
+        let mut done = false;
+        while !done {
+            state
+                .foreach_up_to_epoch(&store, 10, Some(2), |epoch, _, _| {
+                    processed.push(epoch);
+                    Ok(())
+                })
+                .unwrap();
+            done = state.next_idx.is_none();
+        }
+
+        // Should get all epochs in order, despite gaps
+        assert_eq!(processed, vec![1, 2, 4, 7, 8, 10]);
+    }
+
+    #[test]
+    fn test_expiries_pagination_with_mutations() {
+        let store = MemoryBlockstore::default();
+        let mut state = ExpiriesState::new(&store).unwrap();
+        let addr = new_address();
+        let current_epoch = 100;
+
+        // Initial set: 110,120,130,140,150
+        let mut hashes = vec![];
+        for ttl in (10..=50).step_by(10) {
+            let (hash, _) = new_hash(1024);
+            state
+                .update_index(
+                    &store,
+                    addr,
+                    hash,
+                    &SubscriptionId::default(),
+                    vec![ExpiryUpdate::Add(current_epoch + ttl)],
+                )
+                .unwrap();
+            hashes.push(hash);
+        }
+
+        let mut processed = vec![];
+
+        // Process first batch (110,120)
+        state
+            .foreach_up_to_epoch(&store, 150, Some(2), |epoch, _, _| {
+                processed.push(epoch);
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(processed, vec![110, 120]);
+
+        // Add new expiry at 135
+        let (hash, _) = new_hash(1024);
+        state
+            .update_index(
+                &store,
+                addr,
+                hash,
+                &SubscriptionId::default(),
+                vec![ExpiryUpdate::Add(current_epoch + 35)],
+            )
+            .unwrap();
+
+        // Remove expiry at 140
+        let hash = hashes[3];
+        state
+            .update_index(
+                &store,
+                addr,
+                hash,
+                &SubscriptionId::default(),
+                vec![ExpiryUpdate::Remove(current_epoch + 40)],
+            )
+            .unwrap();
+
+        // Process remaining epochs
+        while state.next_idx.is_some() {
+            state
+                .foreach_up_to_epoch(&store, 150, Some(2), |epoch, _, _| {
+                    processed.push(epoch);
+                    Ok(())
+                })
+                .unwrap();
+        }
+
+        // Should get all expiries in order, with 140 removed and 135 added
+        assert_eq!(processed, vec![110, 120, 130, 135, 150]);
+    }
+
+    #[test]
+    fn test_expiries_pagination_with_expiry_update() {
+        let store = MemoryBlockstore::default();
+        let mut state = ExpiriesState::new(&store).unwrap();
+        let addr = new_address();
+        let current_epoch = 100;
+
+        // Initial set: add blobs with ttl 10,20,30,40,50
+        let mut hashes = vec![];
+        for ttl in (10..=50).step_by(10) {
+            let (hash, _) = new_hash(1024);
+            let expiry = current_epoch + ttl;
+            state
+                .update_index(
+                    &store,
+                    addr,
+                    hash,
+                    &SubscriptionId::default(),
+                    vec![ExpiryUpdate::Add(expiry)],
+                )
+                .unwrap();
+            hashes.push(hash);
+        }
+
+        let mut processed = vec![];
+
+        // Process first two expiries (110,120)
+        state
+            .foreach_up_to_epoch(&store, 150, Some(2), |epoch, _, _| {
+                processed.push(epoch);
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(processed, vec![110, 120]);
+
+        // Extend expiry of the blob at 130 to 145 (can only extend, not reduce)
+        let hash = hashes[2]; // blob with ttl 30
+        state
+            .update_index(
+                &store,
+                addr,
+                hash,
+                &SubscriptionId::default(),
+                vec![
+                    ExpiryUpdate::Remove(current_epoch + 30), // remove 130
+                    ExpiryUpdate::Add(current_epoch + 45),    // add 145 (extended)
+                ],
+            )
+            .unwrap();
+
+        // Process remaining epochs - should see updated expiry
+        while state.next_idx.is_some() {
+            state
+                .foreach_up_to_epoch(&store, 150, Some(2), |epoch, _, _| {
+                    processed.push(epoch);
+                    Ok(())
+                })
+                .unwrap();
+        }
+
+        // Should get all expiries in chronological order, with 130 replaced by 145
+        assert_eq!(processed, vec![110, 120, 140, 145, 150]);
+    }
+
+    #[test]
+    fn test_expiries_pagination_with_multiple_subscribers() {
+        let store = MemoryBlockstore::default();
+        let mut state = ExpiriesState::new(&store).unwrap();
+        let addr1 = new_address();
+        let addr2 = new_address();
+
+        // Add multiple blobs expiring at the same epochs
+        // addr1: two blobs expiring at 110, one at 120
+        // addr2: one blob expiring at 110, two at 130
+        let mut entries = vec![];
+
+        // addr1's blobs
+        for _ in 0..2 {
+            let (hash, _) = new_hash(1024);
+            state
+                .update_index(
+                    &store,
+                    addr1,
+                    hash,
+                    &SubscriptionId::default(),
+                    vec![ExpiryUpdate::Add(110)],
+                )
+                .unwrap();
+            entries.push((110, addr1, hash));
+        }
+        let (hash, _) = new_hash(1024);
+        state
+            .update_index(
+                &store,
+                addr1,
+                hash,
+                &SubscriptionId::default(),
+                vec![ExpiryUpdate::Add(120)],
+            )
+            .unwrap();
+        entries.push((120, addr1, hash));
+
+        // addr2's blobs
+        let (hash, _) = new_hash(1024);
+        state
+            .update_index(
+                &store,
+                addr2,
+                hash,
+                &SubscriptionId::default(),
+                vec![ExpiryUpdate::Add(110)],
+            )
+            .unwrap();
+        entries.push((110, addr2, hash));
+
+        for _ in 0..2 {
+            let (hash, _) = new_hash(1024);
+            state
+                .update_index(
+                    &store,
+                    addr2,
+                    hash,
+                    &SubscriptionId::default(),
+                    vec![ExpiryUpdate::Add(130)],
+                )
+                .unwrap();
+            entries.push((130, addr2, hash));
+        }
+
+        let mut processed = vec![];
+        let mut done = false;
+
+        // Process all entries with batch size 2
+        while !done {
+            state
+                .foreach_up_to_epoch(&store, 150, Some(2), |epoch, subscriber, key| {
+                    processed.push((epoch, subscriber, key.hash));
+                    Ok(())
+                })
+                .unwrap();
+            done = state.next_idx.is_none();
+        }
+
+        // Should get all entries, with multiple entries per epoch
+        assert_eq!(processed.len(), 6); // Total number of blob expiries
+
+        // Verify we got all entries at epoch 110
+        let epoch_110 = processed.iter().filter(|(e, _, _)| *e == 110).count();
+        assert_eq!(epoch_110, 3); // 2 from addr1, 1 from addr2
+
+        // Verify we got all entries at epoch 130
+        let epoch_130 = processed.iter().filter(|(e, _, _)| *e == 130).count();
+        assert_eq!(epoch_130, 2); // Both from addr2
     }
 }

--- a/fendermint/actors/recall_config/shared/src/lib.rs
+++ b/fendermint/actors/recall_config/shared/src/lib.rs
@@ -49,8 +49,8 @@ impl Default for RecallConfig {
             blob_credit_debit_interval: ChainEpoch::from(60 * 10), // ~10 min
             blob_min_ttl: ChainEpoch::from(60 * 60),               // ~1 hour
             blob_default_ttl: ChainEpoch::from(60 * 60 * 24),      // ~1 day
-            blob_delete_batch_size: 150, // Default from previous hardcoded value
-            account_debit_batch_size: 2000, // Default from previous hardcoded value
+            blob_delete_batch_size: 150,
+            account_debit_batch_size: 2000,
         }
     }
 }

--- a/fendermint/actors/recall_config/shared/src/lib.rs
+++ b/fendermint/actors/recall_config/shared/src/lib.rs
@@ -49,8 +49,8 @@ impl Default for RecallConfig {
             blob_credit_debit_interval: ChainEpoch::from(60 * 10), // ~10 min
             blob_min_ttl: ChainEpoch::from(60 * 60),               // ~1 hour
             blob_default_ttl: ChainEpoch::from(60 * 60 * 24),      // ~1 day
-            blob_delete_batch_size: 150,
-            account_debit_batch_size: 2000,
+            blob_delete_batch_size: 100,
+            account_debit_batch_size: 1000,
         }
     }
 }

--- a/fendermint/actors/recall_config/shared/src/lib.rs
+++ b/fendermint/actors/recall_config/shared/src/lib.rs
@@ -32,6 +32,10 @@ pub struct RecallConfig {
     pub blob_min_ttl: ChainEpoch,
     /// The default epoch duration a blob is stored.
     pub blob_default_ttl: ChainEpoch,
+    /// Maximum number of blobs to delete in a single batch during debit.
+    pub blob_delete_batch_size: u64,
+    /// Maximum number of accounts to process in a single batch during debit.
+    pub account_debit_batch_size: u64,
 }
 
 impl Default for RecallConfig {
@@ -45,6 +49,8 @@ impl Default for RecallConfig {
             blob_credit_debit_interval: ChainEpoch::from(60 * 10), // ~10 min
             blob_min_ttl: ChainEpoch::from(60 * 60),               // ~1 hour
             blob_default_ttl: ChainEpoch::from(60 * 60 * 24),      // ~1 day
+            blob_delete_batch_size: 150, // Default from previous hardcoded value
+            account_debit_batch_size: 2000, // Default from previous hardcoded value
         }
     }
 }

--- a/fendermint/actors/recall_config/src/lib.rs
+++ b/fendermint/actors/recall_config/src/lib.rs
@@ -130,6 +130,18 @@ impl Actor {
                 "default TTL must be greater than or equal to minimum TTL"
             ));
         }
+        if params.blob_delete_batch_size <= 0 {
+            return Err(actor_error!(
+                illegal_argument,
+                "blob delete batch size must be positive"
+            ));
+        }
+        if params.account_debit_batch_size <= 0 {
+            return Err(actor_error!(
+                illegal_argument,
+                "account debit batch size must be positive"
+            ));
+        }
 
         let (admin_id_addr, admin_delegated_addr) = if !admin_exists {
             // The first caller becomes admin

--- a/fendermint/actors/recall_config/src/lib.rs
+++ b/fendermint/actors/recall_config/src/lib.rs
@@ -40,6 +40,8 @@ pub struct ConstructorParams {
     initial_blob_credit_debit_interval: ChainEpoch,
     initial_blob_min_ttl: ChainEpoch,
     initial_blob_default_ttl: ChainEpoch,
+    initial_blob_delete_batch_size: u64,
+    initial_account_debit_batch_size: u64,
 }
 
 pub struct Actor {}
@@ -56,6 +58,8 @@ impl Actor {
                 blob_credit_debit_interval: params.initial_blob_credit_debit_interval,
                 blob_min_ttl: params.initial_blob_min_ttl,
                 blob_default_ttl: params.initial_blob_default_ttl,
+                blob_delete_batch_size: params.initial_blob_delete_batch_size,
+                account_debit_batch_size: params.initial_account_debit_batch_size,
             },
         };
         rt.create(&st)
@@ -248,6 +252,8 @@ mod tests {
                     ),
                     initial_blob_min_ttl,
                     initial_blob_default_ttl,
+                    initial_blob_delete_batch_size: 100,
+                    initial_account_debit_batch_size: 100,
                 })
                 .unwrap(),
             )
@@ -302,10 +308,19 @@ mod tests {
         rt.expect_validate_caller_any();
         let event = to_actor_event(config_admin_set(f4_eth_addr).unwrap()).unwrap();
         rt.expect_emitted_event(event);
-        let params = SetAdminParams(f4_eth_addr);
+        SetAdminParams(f4_eth_addr);
         let result = rt.call::<Actor>(
-            Method::SetAdmin as u64,
-            IpldBlock::serialize_cbor(&params).unwrap(),
+            Method::SetConfig as u64,
+            IpldBlock::serialize_cbor(&RecallConfig {
+                blob_capacity: 2048,
+                token_credit_rate: TokenCreditRate::from(BigInt::from(10)),
+                blob_credit_debit_interval: ChainEpoch::from(1800),
+                blob_min_ttl: ChainEpoch::from(2 * 60 * 60),
+                blob_default_ttl: ChainEpoch::from(24 * 60 * 60),
+                blob_delete_batch_size: 100,
+                account_debit_batch_size: 100,
+            })
+            .unwrap(),
         );
         assert!(result.is_ok());
         rt.verify();
@@ -431,6 +446,8 @@ mod tests {
             blob_credit_debit_interval: ChainEpoch::from(1800),
             blob_min_ttl: ChainEpoch::from(2 * 60 * 60),
             blob_default_ttl: ChainEpoch::from(24 * 60 * 60),
+            blob_delete_batch_size: 100,
+            account_debit_batch_size: 100,
         };
         let event = to_actor_event(
             config_set(
@@ -501,6 +518,8 @@ mod tests {
             blob_credit_debit_interval: ChainEpoch::from(1800),
             blob_min_ttl: ChainEpoch::from(2 * 60 * 60),
             blob_default_ttl: ChainEpoch::from(24 * 60 * 60),
+            blob_delete_batch_size: 100,
+            account_debit_batch_size: 100,
         };
 
         let test_cases = vec![

--- a/fendermint/actors/recall_config/src/lib.rs
+++ b/fendermint/actors/recall_config/src/lib.rs
@@ -130,13 +130,13 @@ impl Actor {
                 "default TTL must be greater than or equal to minimum TTL"
             ));
         }
-        if params.blob_delete_batch_size <= 0 {
+        if params.blob_delete_batch_size == 0 {
             return Err(actor_error!(
                 illegal_argument,
                 "blob delete batch size must be positive"
             ));
         }
-        if params.account_debit_batch_size <= 0 {
+        if params.account_debit_batch_size == 0 {
             return Err(actor_error!(
                 illegal_argument,
                 "account debit batch size must be positive"
@@ -320,7 +320,6 @@ mod tests {
         rt.expect_validate_caller_any();
         let event = to_actor_event(config_admin_set(f4_eth_addr).unwrap()).unwrap();
         rt.expect_emitted_event(event);
-        SetAdminParams(f4_eth_addr);
         let result = rt.call::<Actor>(
             Method::SetConfig as u64,
             IpldBlock::serialize_cbor(&RecallConfig {
@@ -360,10 +359,9 @@ mod tests {
         rt.expect_validate_caller_addr(vec![id_addr]);
         let event = to_actor_event(config_admin_set(new_f4_eth_addr).unwrap()).unwrap();
         rt.expect_emitted_event(event);
-        let params = SetAdminParams(new_f4_eth_addr);
         let result = rt.call::<Actor>(
             Method::SetAdmin as u64,
-            IpldBlock::serialize_cbor(&params).unwrap(),
+            IpldBlock::serialize_cbor(&SetAdminParams(new_f4_eth_addr)).unwrap(),
         );
         assert!(result.is_ok());
         rt.verify();
@@ -401,10 +399,9 @@ mod tests {
         rt.expect_validate_caller_any();
         let event = to_actor_event(config_admin_set(f4_eth_addr).unwrap()).unwrap();
         rt.expect_emitted_event(event);
-        let params = SetAdminParams(f4_eth_addr);
         let result = rt.call::<Actor>(
             Method::SetAdmin as u64,
-            IpldBlock::serialize_cbor(&params).unwrap(),
+            IpldBlock::serialize_cbor(&SetAdminParams(f4_eth_addr)).unwrap(),
         );
         assert!(result.is_ok());
         rt.verify();
@@ -420,10 +417,9 @@ mod tests {
 
         rt.set_caller(*ETHACCOUNT_ACTOR_CODE_ID, unauthorized_id_addr); // unauthorized caller
         rt.expect_validate_caller_addr(vec![id_addr]); // expect current admin
-        let params = SetAdminParams(unauthorized_f4_eth_addr);
         let result = rt.call::<Actor>(
             Method::SetAdmin as u64,
-            IpldBlock::serialize_cbor(&params).unwrap(),
+            IpldBlock::serialize_cbor(&SetAdminParams(unauthorized_f4_eth_addr)).unwrap(),
         );
         rt.verify();
 
@@ -452,34 +448,18 @@ mod tests {
         rt.expect_validate_caller_any();
         let event = to_actor_event(config_admin_set(f4_eth_addr).unwrap()).unwrap();
         rt.expect_emitted_event(event);
-        let params = RecallConfig {
-            blob_capacity: 2048,
-            token_credit_rate: TokenCreditRate::from(BigInt::from(10)),
-            blob_credit_debit_interval: ChainEpoch::from(1800),
-            blob_min_ttl: ChainEpoch::from(2 * 60 * 60),
-            blob_default_ttl: ChainEpoch::from(24 * 60 * 60),
-            blob_delete_batch_size: 100,
-            account_debit_batch_size: 100,
-        };
-        let event = to_actor_event(
-            config_set(
-                params.blob_capacity,
-                params
-                    .token_credit_rate
-                    .rate()
-                    .to_biguint()
-                    .unwrap_or_default(),
-                params.blob_credit_debit_interval as u64,
-                params.blob_min_ttl as u64,
-                params.blob_default_ttl as u64,
-            )
-            .unwrap(),
-        )
-        .unwrap();
-        rt.expect_emitted_event(event);
         let result = rt.call::<Actor>(
             Method::SetConfig as u64,
-            IpldBlock::serialize_cbor(&params).unwrap(),
+            IpldBlock::serialize_cbor(&RecallConfig {
+                blob_capacity: 2048,
+                token_credit_rate: TokenCreditRate::from(BigInt::from(10)),
+                blob_credit_debit_interval: ChainEpoch::from(1800),
+                blob_min_ttl: ChainEpoch::from(2 * 60 * 60),
+                blob_default_ttl: ChainEpoch::from(24 * 60 * 60),
+                blob_delete_batch_size: 100,
+                account_debit_batch_size: 100,
+            })
+            .unwrap(),
         );
         assert!(result.is_ok());
         rt.verify();

--- a/fendermint/actors/recall_config/src/lib.rs
+++ b/fendermint/actors/recall_config/src/lib.rs
@@ -174,8 +174,8 @@ impl Actor {
                 params.blob_credit_debit_interval as u64,
                 params.blob_min_ttl as u64,
                 params.blob_default_ttl as u64,
-                params.blob_delete_batch_size as u64,
-                params.account_debit_batch_size as u64,
+                params.blob_delete_batch_size,
+                params.account_debit_batch_size,
             ),
         )?;
 
@@ -463,8 +463,8 @@ mod tests {
                 config.blob_credit_debit_interval as u64,
                 config.blob_min_ttl as u64,
                 config.blob_default_ttl as u64,
-                config.blob_delete_batch_size as u64,
-                config.account_debit_batch_size as u64,
+                config.blob_delete_batch_size,
+                config.account_debit_batch_size,
             )
             .unwrap(),
         )

--- a/fendermint/vm/interpreter/src/chain.rs
+++ b/fendermint/vm/interpreter/src/chain.rs
@@ -863,7 +863,7 @@ where
                         gas_limit = gas_limit,
                         gas_used = apply_ret.msg_receipt.gas_used,
                         info = info.unwrap_or_default(),
-                        "implicit tx delivered"
+                        "====>>>> implicit tx delivered"
                     );
                     tracing::debug!("chain interpreter debited accounts");
 

--- a/fendermint/vm/interpreter/src/chain.rs
+++ b/fendermint/vm/interpreter/src/chain.rs
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::selector::{GasLimitSelector, MessageSelector};
@@ -53,8 +53,6 @@ use fendermint_vm_topdown::voting::{ValidatorKey, VoteTally};
 use fendermint_vm_topdown::{
     CachedFinalityProvider, IPCParentFinality, ParentFinalityProvider, ParentViewProvider, Toggle,
 };
-use fvm::executor::{ApplyFailure, ApplyRet};
-use fvm::{call_manager::Backtrace, trace::ExecutionTrace};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
@@ -62,7 +60,6 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::message::Message;
 use fvm_shared::MethodNum;
-use fvm_shared::{error::ExitCode, receipt::Receipt};
 use iroh::base::key::PublicKey;
 use iroh::blobs::Hash;
 use iroh::net::NodeId;

--- a/fendermint/vm/interpreter/src/chain.rs
+++ b/fendermint/vm/interpreter/src/chain.rs
@@ -863,7 +863,7 @@ where
                         gas_limit = gas_limit,
                         gas_used = apply_ret.msg_receipt.gas_used,
                         info = info.unwrap_or_default(),
-                        "====>>>> implicit tx delivered"
+                        "implicit tx delivered"
                     );
                     tracing::debug!("chain interpreter debited accounts");
 

--- a/fendermint/vm/interpreter/src/fvm/recall_config.rs
+++ b/fendermint/vm/interpreter/src/fvm/recall_config.rs
@@ -27,6 +27,10 @@ pub struct RecallConfigTracker {
     pub blob_min_ttl: ChainEpoch,
     /// The default epoch duration a blob is stored.
     pub blob_default_ttl: ChainEpoch,
+    /// The number of blobs to delete in a single batch.
+    pub blob_delete_batch_size: u64,
+    /// The number of accounts to debit in a single batch.
+    pub account_debit_batch_size: u64,
 }
 
 impl RecallConfigTracker {
@@ -37,6 +41,8 @@ impl RecallConfigTracker {
             blob_credit_debit_interval: Zero::zero(),
             blob_min_ttl: Zero::zero(),
             blob_default_ttl: Zero::zero(),
+            blob_delete_batch_size: Zero::zero(),
+            account_debit_batch_size: Zero::zero(),
         };
 
         let reading = Self::read_recall_config(executor)?;
@@ -46,6 +52,8 @@ impl RecallConfigTracker {
         ret.blob_credit_debit_interval = reading.blob_credit_debit_interval;
         ret.blob_min_ttl = reading.blob_min_ttl;
         ret.blob_default_ttl = reading.blob_default_ttl;
+        ret.blob_delete_batch_size = reading.blob_delete_batch_size;
+        ret.account_debit_batch_size = reading.account_debit_batch_size;
 
         Ok(ret)
     }


### PR DESCRIPTION
- Paginate account debiting using HAMT's `for_each_ranged` method. Store the next address process in the current debit cycle in the state.
- Paginate blob deletion by keeping the next index of AMT in the state

closes #478 