### PR TITLE
feat: bundle and tag all related blobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,7 +2852,7 @@ dependencies = [
 [[package]]
 name = "entangler"
 version = "0.1.0"
-source = "git+https://github.com/recallnet/entanglement.git?rev=c578aa2973c8c31cecb26a92546051a3ec03de89#c578aa2973c8c31cecb26a92546051a3ec03de89"
+source = "git+https://github.com/recallnet/entanglement.git?rev=3afdd946d6d3eee6776c017eaf5d68dfecf80675#3afdd946d6d3eee6776c017eaf5d68dfecf80675"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11979,7 +11979,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage"
 version = "0.1.0"
-source = "git+https://github.com/recallnet/entanglement.git?rev=c578aa2973c8c31cecb26a92546051a3ec03de89#c578aa2973c8c31cecb26a92546051a3ec03de89"
+source = "git+https://github.com/recallnet/entanglement.git?rev=3afdd946d6d3eee6776c017eaf5d68dfecf80675#3afdd946d6d3eee6776c017eaf5d68dfecf80675"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,8 +90,8 @@ data-encoding = { version = "2.3.3" }
 dirs = "5.0"
 dircpy = "0.3.19"
 either = "1.10"
-entangler = { git = "https://github.com/recallnet/entanglement.git", rev = "c578aa2973c8c31cecb26a92546051a3ec03de89" }
-entangler_storage = { package = "storage", git = "https://github.com/recallnet/entanglement.git", rev = "c578aa2973c8c31cecb26a92546051a3ec03de89" }
+entangler = { git = "https://github.com/recallnet/entanglement.git", rev = "3afdd946d6d3eee6776c017eaf5d68dfecf80675" }
+entangler_storage = { package = "storage", git = "https://github.com/recallnet/entanglement.git", rev = "3afdd946d6d3eee6776c017eaf5d68dfecf80675" }
 env_logger = "0.10"
 erased-serde = "0.3"
 ethers = { version = "2.0.13", features = ["abigen", "ws"] }


### PR DESCRIPTION
Resolves https://github.com/recallnet/entanglement/issues/25

After uploading a blob and entangling it a new hash sequence is being created that bundles all relevant blob hashes: for original blob, metadata blob and parity blobs.
Instead of returning an original blob's hash we return the hash of the hash sequence.

During the upload process all the blobs are assigned auto tags that are deleted in the end of the upload. The hash sequence is being assigned a "temp-{hash_seq_hash}" tag that will eventually be replaced with "stored-{hash_seq_hash}" by the validator.