### PR TITLE
refactor: blob upload to use fixed tags instead of auto tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -95,7 +95,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -1001,7 +1001,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "instant",
  "rand",
 ]
@@ -2998,7 +2998,7 @@ dependencies = [
  "sha2 0.10.8",
  "sha3",
  "thiserror 1.0.69",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -3849,6 +3849,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "uuid 1.15.1",
  "warp",
 ]
 
@@ -5324,8 +5325,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6774,7 +6787,7 @@ dependencies = [
  "data-encoding",
  "derive_more",
  "ed25519-dalek",
- "getrandom",
+ "getrandom 0.2.15",
  "hex",
  "iroh-blake3",
  "once_cell",
@@ -7453,7 +7466,7 @@ dependencies = [
  "either",
  "futures",
  "futures-timer",
- "getrandom",
+ "getrandom 0.2.15",
  "instant",
  "libp2p-allow-block-list",
  "libp2p-connection-limits",
@@ -7586,7 +7599,7 @@ dependencies = [
  "fnv",
  "futures",
  "futures-ticker",
- "getrandom",
+ "getrandom 0.2.15",
  "hex_fmt",
  "instant",
  "libp2p-core",
@@ -8310,7 +8323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -8435,7 +8448,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -10031,7 +10044,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -10174,7 +10187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
- "getrandom",
+ "getrandom 0.2.15",
  "rand",
  "ring 0.17.8",
  "rustc-hash 2.1.0",
@@ -10254,7 +10267,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -10473,7 +10486,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -10729,7 +10742,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -12624,7 +12637,7 @@ dependencies = [
  "bytes",
  "flex-error",
  "futures",
- "getrandom",
+ "getrandom 0.2.15",
  "http 0.2.12",
  "hyper 0.14.31",
  "hyper-proxy",
@@ -12644,7 +12657,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "uuid",
+ "uuid 0.8.2",
  "walkdir",
 ]
 
@@ -13536,8 +13549,17 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
+]
+
+[[package]]
+name = "uuid"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
+dependencies = [
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -13661,6 +13683,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -14427,6 +14458,15 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,7 +2852,7 @@ dependencies = [
 [[package]]
 name = "entangler"
 version = "0.1.0"
-source = "git+https://github.com/recallnet/entanglement.git?rev=3afdd946d6d3eee6776c017eaf5d68dfecf80675#3afdd946d6d3eee6776c017eaf5d68dfecf80675"
+source = "git+https://github.com/recallnet/entanglement.git?branch=dig/tags#537afe56c074c5bcc7c4c380e6cb029971335096"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11979,7 +11979,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage"
 version = "0.1.0"
-source = "git+https://github.com/recallnet/entanglement.git?rev=3afdd946d6d3eee6776c017eaf5d68dfecf80675#3afdd946d6d3eee6776c017eaf5d68dfecf80675"
+source = "git+https://github.com/recallnet/entanglement.git?branch=dig/tags#537afe56c074c5bcc7c4c380e6cb029971335096"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,6 +197,7 @@ tracing-subscriber = { version = "0.3", features = [
     "registry",
 ] }
 tracing-appender = "0.2.3"
+uuid = { version = "1.15.1", features = ["v4" ] }
 url = { version = "2.4.1", features = ["serde"] }
 warp = "0.3.7"
 zeroize = "1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,8 +90,8 @@ data-encoding = { version = "2.3.3" }
 dirs = "5.0"
 dircpy = "0.3.19"
 either = "1.10"
-entangler = { git = "https://github.com/recallnet/entanglement.git", rev = "3afdd946d6d3eee6776c017eaf5d68dfecf80675" }
-entangler_storage = { package = "storage", git = "https://github.com/recallnet/entanglement.git", rev = "3afdd946d6d3eee6776c017eaf5d68dfecf80675" }
+entangler = { git = "https://github.com/recallnet/entanglement.git", branch = "dig/tags" }
+entangler_storage = { package = "storage", git = "https://github.com/recallnet/entanglement.git", branch = "dig/tags" }
 env_logger = "0.10"
 erased-serde = "0.3"
 ethers = { version = "2.0.13", features = ["abigen", "ws"] }

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -48,6 +48,7 @@ tower-abci = { workspace = true }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
+uuid = { workspace = true }
 warp = { workspace = true }
 
 fendermint_abci = { path = "../abci" }

--- a/fendermint/app/src/cmd/objects.rs
+++ b/fendermint/app/src/cmd/objects.rs
@@ -23,7 +23,7 @@ use fvm_shared::{
 };
 use ipc_api::ethers_address_to_fil_address;
 use iroh::{
-    blobs::{hashseq::HashSeq, provider::AddProgress, util::SetTagOption, Hash, HashAndFormat},
+    blobs::{hashseq::HashSeq, util::SetTagOption, Hash, HashAndFormat},
     client::blobs::BlobStatus,
     net::NodeAddr,
 };
@@ -330,6 +330,8 @@ async fn handle_object_upload(
                     }))
                 }
             };
+
+            let tag = iroh::blobs::Tag(format!("temp-{hash}").into());
             let progress = iroh
                 .blobs()
                 .download_with_opts(
@@ -337,7 +339,7 @@ async fn handle_object_upload(
                     iroh::client::blobs::DownloadOptions {
                         format: iroh::blobs::BlobFormat::Raw,
                         nodes: vec![source],
-                        tag: SetTagOption::Auto,
+                        tag: SetTagOption::Named(tag),
                         mode: iroh::client::blobs::DownloadMode::Queued,
                     },
                 )
@@ -380,42 +382,41 @@ async fn handle_object_upload(
                     })
             });
 
-            let mut progress = iroh
-                .blobs()
-                .add_stream(stream, SetTagOption::Auto)
-                .await
-                .map_err(|e| {
-                    Rejection::from(BadRequest {
-                        message: format!("failed to store blob: {}", e),
-                    })
-                })?;
+            let batch = iroh.blobs().batch().await.map_err(|e| {
+                Rejection::from(BadRequest {
+                    message: format!("failed to store blob: {}", e),
+                })
+            })?;
+            let temp_tag = batch.add_stream(stream).await.map_err(|e| {
+                Rejection::from(BadRequest {
+                    message: format!("failed to store blob: {}", e),
+                })
+            })?;
 
-            let uploaded_hash = loop {
-                let Some(event) = progress.next().await else {
-                    return Err(Rejection::from(BadRequest {
-                        message: "Unexpected end while ingesting data".to_string(),
-                    }));
-                };
-                match event.map_err(|e| {
-                    Rejection::from(BadRequest {
-                        message: format!("failed to make progress: {}", e),
-                    })
-                })? {
-                    AddProgress::AllDone { hash, .. } => {
-                        break hash;
-                    }
-                    AddProgress::Abort(err) => {
-                        return Err(Rejection::from(BadRequest {
-                            message: format!("upload aborted: {}", err),
-                        }));
-                    }
-                    _ => continue,
-                }
+            let hash = *temp_tag.hash();
+            let new_tag = iroh::blobs::Tag(format!("temp-{hash}").into());
+            batch.persist_to(temp_tag, new_tag).await.map_err(|e| {
+                Rejection::from(BadRequest {
+                    message: format!("failed to persist blob: {}", e),
+                })
+            })?;
+
+            drop(batch);
+
+            let status = iroh.blobs().status(hash).await.map_err(|e| {
+                Rejection::from(BadRequest {
+                    message: format!("failed to check blob status: {}", e),
+                })
+            })?;
+            let BlobStatus::Complete { size } = status else {
+                return Err(Rejection::from(BadRequest {
+                    message: "failed to store data".to_string(),
+                }));
             };
-            info!("stored uploaded blob {} (size: {})", uploaded_hash, size);
             COUNTER_BYTES_UPLOADED.inc_by(size);
+            info!("stored uploaded blob {} (size: {})", hash, size);
 
-            uploaded_hash
+            hash
         }
 
         (Some(_), Some(_)) => {
@@ -465,51 +466,52 @@ async fn tag_entangled_data(
     ent: &Entangler<EntanglerIrohStorage>,
     metadata_hash: &String,
 ) -> Result<Hash, anyhow::Error> {
+    // entangler tags: ent-{hash}
+    // uploaded tags: temp-{hash}
+    // hash seq tags: temp-seq-{hash-seq-hash}
+
     let metadata = ent.download_metadata(metadata_hash).await?;
     let orig_hash = Hash::from_str(metadata.orig_hash.as_str())?;
-    // collect all hashes related to the blob
-    let mut hashes = vec![orig_hash.clone(), Hash::from_str(metadata_hash.as_str())?];
-    for (_, blob_hash) in metadata.parity_hashes {
-        hashes.push(Hash::from_str(blob_hash.as_str())?);
-    }
+    let metadata_hash = Hash::from_str(metadata_hash.as_str())?;
 
-    // iterate over all tags and find the ones that are related to the blob
-    let temp_tags: Vec<_> = iroh
-        .tags()
-        .list()
-        .await?
-        .try_filter_map(|tag| {
-            let cloned_hashes = hashes.clone();
-            async move {
-                if cloned_hashes.contains(&tag.hash) {
-                    Ok(Some(tag.name))
-                } else {
-                    Ok(None)
-                }
-            }
-        })
-        .try_collect()
-        .await?;
+    // collect all hashes related to the blob
+    let parity_hashes = metadata
+        .parity_hashes
+        .iter()
+        .map(|(_, hash)| Hash::from_str(hash.as_str()))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut hashes = vec![orig_hash.clone(), metadata_hash];
+    hashes.extend_from_slice(&parity_hashes);
+
+    let batch = iroh.blobs().batch().await?;
 
     // make a hash sequence object from the hashes and upload it to iroh
     let hash_seq = hashes.into_iter().collect::<HashSeq>();
-    let res = iroh.blobs().add_bytes(hash_seq).await?;
+    let temp_tag = batch.add_bytes(hash_seq).await?;
 
-    // assign a consistent tag to the hash sequence object
-    let batch = iroh.blobs().batch().await?;
-    let temp_tag = batch.temp_tag(HashAndFormat::hash_seq(res.hash)).await?;
-    let hash_seq_hash = res.hash;
+    let hash_seq_hash = *temp_tag.hash();
     // this tag will be replaced later by the validator to "stored-{hash_seq_hash}"
-    let hash_seq_tag = iroh::blobs::Tag(format!("temp-{hash_seq_hash}").into());
+    let hash_seq_tag = iroh::blobs::Tag(format!("temp-seq-{hash_seq_hash}").into());
     batch.persist_to(temp_tag, hash_seq_tag).await?;
 
-    // delete all temporary tags
-    for temp_tag in temp_tags {
-        iroh.tags().delete(temp_tag).await?;
-    }
-    iroh.tags().delete(res.tag).await?;
+    drop(batch);
 
-    Ok(res.hash)
+    // delete all previous temporary tags
+    for parity_hash in parity_hashes {
+        let tag = iroh::blobs::Tag(format!("ent-{parity_hash}").into());
+        iroh.tags().delete(tag).await?;
+    }
+
+    // remove upload tags
+    let orig_tag = iroh::blobs::Tag(format!("temp-{orig_hash}").into());
+    iroh.tags().delete(orig_tag).await?;
+
+    // remove entangled metadata
+    let meta_tag = iroh::blobs::Tag(format!("ent-{metadata_hash}").into());
+    iroh.tags().delete(meta_tag).await?;
+
+    Ok(hash_seq_hash)
 }
 
 fn new_entangler(
@@ -980,17 +982,16 @@ mod tests {
                 .map(|hash| Hash::from_str(hash).unwrap()),
         )
         .collect::<HashSeq>();
-        let hash_seq_hash = iroh.blobs().add_bytes(hash_seq).await.unwrap().hash;
+
+        let batch = iroh.blobs().batch().await.unwrap();
+        let temp_tag = batch.add_bytes(hash_seq).await.unwrap();
+        let hash_seq_hash = *temp_tag.hash();
 
         // Add a tag to the hash sequence as expected by the system
-        let batch = iroh.blobs().batch().await.unwrap();
-        let temp_tag = batch
-            .temp_tag(HashAndFormat::hash_seq(hash_seq_hash))
-            .await
-            .unwrap();
-        let tag_name = format!("temp-{hash_seq_hash}");
+        let tag_name = format!("temp-seq-{hash_seq_hash}");
         let hash_seq_tag = iroh::blobs::Tag(tag_name.into());
         batch.persist_to(temp_tag, hash_seq_tag).await.unwrap();
+        drop(batch);
 
         let metadata_iroh_hash = Hash::from_str(metadata_hash.as_str()).unwrap();
 

--- a/ipld/resolver/src/service.rs
+++ b/ipld/resolver/src/service.rs
@@ -672,7 +672,7 @@ pub fn build_transport(local_key: Keypair) -> Boxed<(PeerId, StreamMuxerBox)> {
 async fn download_blob(iroh: Iroh, hash: Hash, node_addr: NodeAddr) -> anyhow::Result<()> {
     // Use an explicit tag so we can keep track of it
     // TODO: this needs to be tagged with a "user id"
-    let tag = iroh::blobs::Tag(format!("stored-{hash}").into());
+    let tag = iroh::blobs::Tag(format!("stored-seq-{hash}").into());
     let res = iroh
         .blobs()
         .download_with_opts(

--- a/ipld/resolver/src/service.rs
+++ b/ipld/resolver/src/service.rs
@@ -691,7 +691,7 @@ async fn download_blob(iroh: Iroh, hash: Hash, node_addr: NodeAddr) -> anyhow::R
 
     // Delete the temporary tag (this might fail as not all nodes will have one).
     // TODO: this needs to be tagged with a "user id"
-    let tag = iroh::blobs::Tag(format!("temp-{hash}").into());
+    let tag = iroh::blobs::Tag(format!("temp-seq-{hash}").into());
     iroh.tags().delete(tag).await.ok();
 
     Ok(())

--- a/recall/syscalls/src/lib.rs
+++ b/recall/syscalls/src/lib.rs
@@ -44,7 +44,7 @@ pub fn hash_rm(context: Context<'_, impl RecallOps>, hash_offset: u32) -> Result
         };
         // Deleting the tag will trigger deletion of the blob if it was the last reference.
         // TODO: this needs to be tagged with a "user id"
-        let tag = iroh::blobs::Tag(format!("stored-{hash}").into());
+        let tag = iroh::blobs::Tag(format!("stored-seq-{hash}").into());
         match iroh_client.tags().delete(tag.clone()).await {
             Ok(_) => tracing::debug!(tag = ?tag, hash = ?hash, "removed content from Iroh"),
             Err(e) => {


### PR DESCRIPTION
Depends on https://github.com/recallnet/entanglement/tree/dig/tags

I don't think the tests fully cover this, but the shape of things should be how I think this would be handled best given the existing apis.

- incoming blobs are tagged `temp-{hash}`
- the entangler tags all blobs they create as `ent-{hash}`
- after entanglement a hash sequence is generated and tagged `temp-seq-{hash}`
- the `temp-` and `ent-` tags relevant to this sequence are deleted
- when the chain upgrades the data, it removes `temp-seq-{hash}` and adds `stored-{hash}`


## Open Questions

- The system currently will fail/race in the situation two blobs are uploaded at the same time, as the tagging is not scoped to a specific upload. This could be solved by introducting another identifier in the tag, or tracking uploads in progress more explicitly somehow
- The way the chain interacts with this, assumes that there is a single tag per stored object, what about the same object being referenced multiple times on chain?
- TTLs for uploaded objects are not yet implemented, this will need to be done in it's own PR
- Currently this uses a simple string based format for tagging, but tags can be arbitrary bytes, so an optimization will be to introduce an actual structural type that gets encoded into the tag name, making this more robust, and easier to extend in the future