### PR TITLE
fix: resolve and get blobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6701,6 +6701,7 @@ dependencies = [
  "log",
  "lru_time_cache",
  "multihash 0.18.1",
+ "num-traits",
  "prometheus",
  "quickcheck",
  "quickcheck_macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3817,6 +3817,7 @@ dependencies = [
  "ipc_ipld_resolver",
  "iroh",
  "iroh-base",
+ "iroh_manager",
  "k256 0.11.6",
  "lazy_static",
  "libipld",
@@ -6710,6 +6711,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "uuid 1.15.1",
 ]
 
 [[package]]
@@ -7122,6 +7124,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "iroh",
+ "num-traits",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6711,7 +6711,6 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "uuid 1.15.1",
 ]
 
 [[package]]

--- a/fendermint/actors/blobs/shared/src/lib.rs
+++ b/fendermint/actors/blobs/shared/src/lib.rs
@@ -172,7 +172,10 @@ pub fn add_blob(
     ))?)
 }
 
-pub fn get_blob(rt: &impl Runtime, hash: state::Hash) -> Result<Option<state::Blob>, ActorError> {
+pub fn get_blob(
+    rt: &impl Runtime,
+    hash: state::Hash,
+) -> Result<Option<state::BlobInfo>, ActorError> {
     deserialize_block(extract_send_result(rt.send(
         &BLOBS_ACTOR_ADDR,
         Method::GetBlob as MethodNum,

--- a/fendermint/actors/blobs/src/actor.rs
+++ b/fendermint/actors/blobs/src/actor.rs
@@ -12,7 +12,7 @@ use fendermint_actor_blobs_shared::params::{
     SetSponsorParams, TrimBlobExpiriesParams, UpdateGasAllowanceParams,
 };
 use fendermint_actor_blobs_shared::state::{
-    AccountInfo, Blob, BlobStatus, Credit, CreditApproval, GasAllowance, Hash, PublicKey,
+    AccountInfo, BlobInfo, BlobStatus, Credit, CreditApproval, GasAllowance, Hash, PublicKey,
     Subscription, SubscriptionId,
 };
 use fendermint_actor_blobs_shared::Method;
@@ -107,7 +107,7 @@ impl BlobsActor {
             credit_purchased(delegated_addr, token_to_biguint(Some(credit_amount))),
         )?;
 
-        AccountInfo::from(account, rt)
+        AccountInfo::from(rt, account)
     }
 
     /// Updates gas allowance for the `from` address.
@@ -319,8 +319,7 @@ impl BlobsActor {
                     .credit_sponsor
                     .map(|sponsor| to_delegated_address(rt, sponsor))
                     .transpose()?;
-
-                AccountInfo::from(account, rt)
+                AccountInfo::from(rt, account)
             });
 
         account.transpose()
@@ -476,10 +475,12 @@ impl BlobsActor {
     }
 
     /// Returns a blob by [`Hash`] if it exists.
-    fn get_blob(rt: &impl Runtime, params: GetBlobParams) -> Result<Option<Blob>, ActorError> {
+    fn get_blob(rt: &impl Runtime, params: GetBlobParams) -> Result<Option<BlobInfo>, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
-        let blob = rt.state::<State>()?.get_blob(rt.store(), params.0)?;
-        Ok(blob)
+        match rt.state::<State>()?.get_blob(rt.store(), params.0)? {
+            Some(blob) => Ok(Some(BlobInfo::from(rt, blob)?)),
+            None => Ok(None),
+        }
     }
 
     /// Returns the current [`BlobStatus`] for a blob by [`Hash`].
@@ -1365,6 +1366,25 @@ mod tests {
         assert_eq!(subscription.expiry, 3605);
         assert_eq!(subscription.delegate, None);
         rt.verify();
+
+        // Get it back
+        rt.expect_validate_caller_any();
+        let get_params = GetBlobParams(hash.0);
+        let blob = rt
+            .call::<BlobsActor>(
+                Method::GetBlob as u64,
+                IpldBlock::serialize_cbor(&get_params).unwrap(),
+            )
+            .unwrap()
+            .unwrap()
+            .deserialize::<Option<BlobInfo>>()
+            .unwrap();
+        assert!(blob.is_some());
+        let blob = blob.unwrap();
+        assert_eq!(blob.size, add_params.size);
+        assert_eq!(blob.metadata_hash, add_params.metadata_hash);
+        assert_eq!(blob.subscribers.len(), 1);
+        assert_eq!(blob.status, BlobStatus::Added);
     }
 
     #[test]

--- a/fendermint/actors/bucket/src/actor.rs
+++ b/fendermint/actors/bucket/src/actor.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 use fendermint_actor_blobs_shared::{
     add_blob, delete_blob, get_blob, has_credit_approval, overwrite_blob,
-    state::{Blob, BlobStatus, SubscriptionId},
+    state::{BlobInfo, BlobStatus, SubscriptionId},
 };
 use fendermint_actor_machine::{
     events::emit_evm_event,
@@ -18,7 +18,6 @@ use fil_actors_runtime::{
     runtime::{ActorCode, Runtime},
     ActorError,
 };
-use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_hamt::BytesKey;
 use fvm_shared::address::Address;
 use recall_sol_facade::bucket::{object_added, object_deleted, object_metadata_updated};
@@ -160,7 +159,7 @@ impl Actor {
         let key = BytesKey(params.0);
         if let Some(object_state) = state.get(rt.store(), &key)? {
             if let Some(blob) = get_blob(rt, object_state.hash)? {
-                let object = build_object(rt.store(), &blob, &object_state, sub_id, owner)?;
+                let object = build_object(&blob, &object_state, sub_id, owner)?;
                 Ok(object)
             } else {
                 Ok(None)
@@ -280,37 +279,27 @@ fn get_blob_id(state: &State, key: &[u8]) -> anyhow::Result<SubscriptionId, Acto
 }
 
 /// Build an object from its state and blob.
-fn build_object<BS: Blockstore>(
-    store: &BS,
-    blob: &Blob,
+fn build_object(
+    blob: &BlobInfo,
     object_state: &ObjectState,
     sub_id: SubscriptionId,
     subscriber: Address,
 ) -> anyhow::Result<Option<Object>, ActorError> {
     match blob.status {
         BlobStatus::Resolved => {
-            let subscribers = blob.subscribers.hamt(store)?;
-            let group = subscribers.get(&subscriber)?.ok_or_else(|| {
+            let expiry = blob.subscribers.get(&sub_id).cloned().ok_or_else(|| {
                 ActorError::illegal_state(format!(
                     "owner {} is not subscribed to blob {}; this should not happen",
                     subscriber, object_state.hash
                 ))
             })?;
-            let (expiry, _) = group.max_expiries(store, &sub_id, None)?;
-            if let Some(expiry) = expiry {
-                Ok(Some(Object {
-                    hash: object_state.hash,
-                    recovery_hash: blob.metadata_hash,
-                    size: blob.size,
-                    expiry,
-                    metadata: object_state.metadata.clone(),
-                }))
-            } else {
-                Err(ActorError::illegal_state(format!(
-                    "subscription group is empty for blob {}; this should not happen",
-                    object_state.hash,
-                )))
-            }
+            Ok(Some(Object {
+                hash: object_state.hash,
+                recovery_hash: blob.metadata_hash,
+                size: blob.size,
+                expiry,
+                metadata: object_state.metadata.clone(),
+            }))
         }
         BlobStatus::Added | BlobStatus::Pending | BlobStatus::Failed => Ok(None),
     }
@@ -401,7 +390,7 @@ mod tests {
             AddBlobParams, DeleteBlobParams, GetBlobParams, GetCreditApprovalParams,
             OverwriteBlobParams,
         },
-        state::{BlobSubscribers, CreditApproval, Hash, Subscription, SubscriptionGroup},
+        state::{CreditApproval, Hash, Subscription},
         Method as BlobMethod, BLOBS_ACTOR_ADDR,
     };
     use fendermint_actor_blobs_testing::{new_hash, new_pk, setup_logs};
@@ -886,39 +875,13 @@ mod tests {
         .unwrap();
         rt.verify();
 
-        let store = rt.store();
-        let blob_subscribers = BlobSubscribers::new(store).unwrap();
-
-        let mut subscribers = blob_subscribers.hamt(store).unwrap();
-
         // Get the object
-        let mut blob = Blob {
+        let blob = BlobInfo {
             size: add_params.size,
-            subscribers: blob_subscribers,
+            subscribers: HashMap::from([(sub_id, ttl)]),
             status: BlobStatus::Resolved,
             metadata_hash: add_params.recovery_hash,
         };
-
-        let mut group = SubscriptionGroup::new(store).unwrap();
-        let mut group_hamt = group.hamt(store).unwrap();
-
-        group.save_tracked(
-            group_hamt
-                .set_and_flush_tracked(
-                    &sub_id,
-                    Subscription {
-                        added: 0,
-                        expiry: ChainEpoch::from(3600),
-                        source: add_params.source,
-                        delegate: Some(origin),
-                        failed: false,
-                    },
-                )
-                .unwrap(),
-        );
-
-        blob.subscribers
-            .save_tracked(subscribers.set_and_flush_tracked(&origin, group).unwrap());
 
         rt.expect_validate_caller_any();
         rt.expect_send(
@@ -962,13 +925,14 @@ mod tests {
         // Add an object
         let hash = new_hash(256);
         let key = vec![0, 1, 2];
+        let ttl = ChainEpoch::from(3600);
         let add_params: AddParams = AddParams {
             source: new_pk(),
             key: key.clone(),
             hash: hash.0,
             size: hash.1,
             recovery_hash: new_hash(256).0,
-            ttl: None,
+            ttl: Some(ttl),
             metadata: HashMap::from([("foo".into(), "bar".into()), ("foo2".into(), "bar".into())]),
             from: origin,
             overwrite: false,
@@ -984,7 +948,7 @@ mod tests {
                 source: add_params.source,
                 hash: add_params.hash,
                 metadata_hash: add_params.recovery_hash,
-                id: sub_id,
+                id: sub_id.clone(),
                 size: add_params.size,
                 ttl: add_params.ttl,
                 from: origin,
@@ -1004,7 +968,6 @@ mod tests {
             .unwrap()
             .deserialize::<Object>()
             .unwrap();
-        let state = rt.state::<State>().unwrap();
         assert_eq!(add_params.hash, result.hash);
         assert_eq!(add_params.metadata, result.metadata);
         assert_eq!(add_params.recovery_hash, result.recovery_hash);
@@ -1125,39 +1088,12 @@ mod tests {
         rt.verify();
 
         // Get the object and check metadata
-        let store = rt.store();
-        let blob_subscribers = BlobSubscribers::new(store).unwrap();
-        let mut subscribers = blob_subscribers.hamt(store).unwrap();
-
-        let sub_id = get_blob_id(&state, &key).unwrap();
-        let mut blob = Blob {
+        let blob = BlobInfo {
             size: add_params.size,
-            subscribers: blob_subscribers,
+            subscribers: HashMap::from([(sub_id, ttl)]),
             status: BlobStatus::Resolved,
             metadata_hash: add_params.recovery_hash,
         };
-
-        let mut group = SubscriptionGroup::new(store).unwrap();
-        let mut group_hamt = group.hamt(store).unwrap();
-
-        group.save_tracked(
-            group_hamt
-                .set_and_flush_tracked(
-                    &sub_id,
-                    Subscription {
-                        added: 0,
-                        expiry: ChainEpoch::from(3600),
-                        source: add_params.source,
-                        delegate: Some(origin),
-                        failed: false,
-                    },
-                )
-                .unwrap(),
-        );
-
-        blob.subscribers
-            .save_tracked(subscribers.set_and_flush_tracked(&origin, group).unwrap());
-
         rt.expect_validate_caller_any();
         rt.expect_send(
             BLOBS_ACTOR_ADDR,

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -94,6 +94,8 @@ ipc-observability = { workspace = true }
 entangler = { workspace = true }
 entangler_storage = { workspace = true }
 
+iroh_manager = { path = "../../recall/iroh_manager" }
+
 [dev-dependencies]
 tempfile = { workspace = true }
 iroh-base = { workspace = true }

--- a/fendermint/app/src/cmd/objects.rs
+++ b/fendermint/app/src/cmd/objects.rs
@@ -483,7 +483,7 @@ async fn tag_entangled_data(
         .filter(|h| h != &metadata_hash)
         .collect::<Vec<_>>();
 
-    let mut hashes = vec![orig_hash.clone(), metadata_hash];
+    let mut hashes = vec![orig_hash, metadata_hash];
     hashes.extend(upload_hashes);
 
     let batch = iroh.blobs().batch().await?;
@@ -944,8 +944,8 @@ mod tests {
         metadata_iroh_hash: Hash,
     ) -> MockQueryClient {
         let object = Object {
-            hash: BlobHash(hash_seq_hash.as_bytes().clone()),
-            recovery_hash: BlobHash(metadata_iroh_hash.as_bytes().clone()),
+            hash: BlobHash(*hash_seq_hash.as_bytes()),
+            recovery_hash: BlobHash(*metadata_iroh_hash.as_bytes()),
             metadata: HashMap::from([
                 ("foo".to_string(), "bar".to_string()),
                 (

--- a/fendermint/app/src/cmd/objects.rs
+++ b/fendermint/app/src/cmd/objects.rs
@@ -11,7 +11,6 @@ use anyhow::Context;
 use bytes::Buf;
 use entangler::{ChunkRange, Config, EntanglementResult, Entangler};
 use entangler_storage::iroh::IrohStorage as EntanglerIrohStorage;
-use fendermint_actor_blobs_shared::state::Hash as BlobHash;
 use fendermint_actor_bucket::{GetParams, Object};
 use fendermint_app_settings::objects::ObjectsSettings;
 use fendermint_rpc::{client::FendermintClient, message::GasParams, QueryClient};
@@ -27,12 +26,12 @@ use iroh::{
     client::blobs::BlobStatus,
     net::NodeAddr,
 };
+use iroh_manager::{extract_blob_hash_and_size, IrohManager};
 use lazy_static::lazy_static;
-use num_traits::Zero;
 use prometheus::{register_histogram, register_int_counter, Histogram, IntCounter};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracing::info;
+use tracing::{debug, info};
 use uuid::Uuid;
 use warp::{
     filters::multipart::Part,
@@ -71,28 +70,23 @@ cmd! {
                 }
 
                 let client = FendermintClient::new_http(tendermint_url, None)?;
-
-                let iroh_addr = iroh_addr
-                    .to_socket_addrs()?
-                    .next()
-                    .ok_or(anyhow!("failed to convert iroh_addr to a socket address"))?;
-                let iroh_client = iroh::client::Iroh::connect_addr(iroh_addr).await?;
+                let iroh_manager = IrohManager::from_addr(Some(iroh_addr));
 
                 // Admin routes
                 let health = warp::path!("health")
                     .and(warp::get()).and_then(handle_health);
                 let node_addr = warp::path!("v1" / "node" )
                 .and(warp::get())
-                .and(with_iroh(iroh_client.clone()))
-                .and_then(handle_node_addr);
+                .and(with_iroh(iroh_manager.clone()))
+                .and_then(handle_node_addr_with_manager);
 
                 // Objects routes
                 let objects_upload = warp::path!("v1" / "objects" )
                 .and(warp::post())
-                .and(with_iroh(iroh_client.clone()))
+                .and(with_iroh(iroh_manager.clone()))
                 .and(warp::multipart::form().max_length(settings.max_object_size + 1024 * 1024)) // max_object_size + 1MB for form overhead
                 .and(with_max_size(settings.max_object_size))
-                .and_then(handle_object_upload);
+                .and_then(handle_object_upload_with_manager);
 
                 let objects_download = warp::path!("v1" / "objects" / String / ..)
                 .and(warp::path::tail())
@@ -102,8 +96,8 @@ cmd! {
                 .and(warp::header::optional::<String>("Range"))
                 .and(warp::query::<HeightQuery>())
                 .and(with_client(client.clone()))
-                .and(with_iroh(iroh_client.clone()))
-                .and_then(handle_object_download);
+                .and(with_iroh(iroh_manager.clone()))
+                .and_then(handle_object_download_with_manager);
 
                 let router = health
                     .or(node_addr)
@@ -132,8 +126,8 @@ fn with_client(
 }
 
 fn with_iroh(
-    client: iroh::client::Iroh,
-) -> impl Filter<Extract = (iroh::client::Iroh,), Error = Infallible> + Clone {
+    client: IrohManager,
+) -> impl Filter<Extract = (IrohManager,), Error = Infallible> + Clone {
     warp::any().map(move || client.clone())
 }
 
@@ -229,7 +223,7 @@ impl ObjectParser {
                 }
                 // Ignore but accept signature-related fields for backward compatibility
                 "chain_id" | "msg" => {
-                    // Just read and discard the data
+                    // Read and discard the data
                     let _ = object_parser.read_part(part).await?;
                 }
                 _ => {
@@ -278,6 +272,15 @@ async fn handle_health() -> Result<impl Reply, Rejection> {
     Ok(warp::reply::reply())
 }
 
+async fn handle_node_addr_with_manager(mut iroh: IrohManager) -> Result<impl Reply, Rejection> {
+    let iroh_client = iroh.client().await.map_err(|e| {
+        Rejection::from(BadRequest {
+            message: format!("failed to load iroh client: {}", e),
+        })
+    })?;
+    handle_node_addr(iroh_client).await
+}
+
 async fn handle_node_addr(iroh: iroh::client::Iroh) -> Result<impl Reply, Rejection> {
     let node_addr = iroh.net().node_addr().await.map_err(|e| {
         Rejection::from(BadRequest {
@@ -291,6 +294,19 @@ async fn handle_node_addr(iroh: iroh::client::Iroh) -> Result<impl Reply, Reject
 struct UploadResponse {
     hash: String,
     metadata_hash: String,
+}
+
+async fn handle_object_upload_with_manager(
+    mut iroh: IrohManager,
+    form_data: warp::multipart::FormData,
+    max_size: u64,
+) -> Result<impl Reply, Rejection> {
+    let iroh_client = iroh.client().await.map_err(|e| {
+        Rejection::from(BadRequest {
+            message: format!("failed to load iroh client: {}", e),
+        })
+    })?;
+    handle_object_upload(iroh_client, form_data, max_size).await
 }
 
 async fn handle_object_upload(
@@ -486,13 +502,25 @@ async fn tag_entangled_data(
     let mut hashes = vec![orig_hash, metadata_hash];
     hashes.extend(upload_hashes);
 
+    let hashes_str = hashes
+        .iter()
+        .map(|h| h.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+
     let batch = iroh.blobs().batch().await?;
 
     // make a hash sequence object from the hashes and upload it to iroh
     let hash_seq = hashes.into_iter().collect::<HashSeq>();
     let temp_tag = batch.add_bytes(hash_seq).await?;
-
     let hash_seq_hash = *temp_tag.hash();
+
+    debug!(
+        "storing hash sequence: {} ({})",
+        hash_seq_hash.to_string(),
+        hashes_str
+    );
+
     // this tag will be replaced later by the validator to "stored-seq-{hash_seq_hash}"
     let hash_seq_tag = iroh::blobs::Tag(format!("temp-seq-{hash_seq_hash}").into());
     batch.persist_to(temp_tag, hash_seq_tag).await?;
@@ -564,6 +592,32 @@ pub(crate) struct ObjectRange {
     body: Body,
 }
 
+async fn handle_object_download_with_manager<F: QueryClient + Send + Sync>(
+    address: String,
+    tail: Tail,
+    method: String,
+    range: Option<String>,
+    height_query: HeightQuery,
+    client: F,
+    mut iroh: IrohManager,
+) -> Result<impl Reply, Rejection> {
+    let iroh_client = iroh.client().await.map_err(|e| {
+        Rejection::from(BadRequest {
+            message: format!("failed to load iroh client: {}", e),
+        })
+    })?;
+    handle_object_download(
+        address,
+        tail,
+        method,
+        range,
+        height_query,
+        client,
+        iroh_client,
+    )
+    .await
+}
+
 async fn handle_object_download<F: QueryClient + Send + Sync>(
     address: String,
     tail: Tail,
@@ -594,13 +648,12 @@ async fn handle_object_download<F: QueryClient + Send + Sync>(
 
     match maybe_object {
         Some(object) => {
-            let (hash, size) = extract_blob_hash_and_size(&iroh, &object.hash)
-                .await
-                .map_err(|e| {
-                    Rejection::from(BadRequest {
-                        message: e.to_string(),
-                    })
-                })?;
+            let hash = Hash::from_bytes(object.hash.0);
+            let (hash, size) = extract_blob_hash_and_size(&iroh, hash).await.map_err(|e| {
+                Rejection::from(BadRequest {
+                    message: e.to_string(),
+                })
+            })?;
 
             let ent = new_entangler(iroh).map_err(|e| {
                 Rejection::from(BadRequest {
@@ -735,72 +788,6 @@ async fn handle_object_download<F: QueryClient + Send + Sync>(
     }
 }
 
-async fn extract_blob_hash_and_size(
-    iroh: &iroh::client::Iroh,
-    object_hash: &BlobHash,
-) -> Result<(Hash, u64), anyhow::Error> {
-    let hash_seq_hash = Hash::from_bytes(object_hash.0);
-    let status = iroh.blobs().status(hash_seq_hash).await.map_err(|e| {
-        anyhow!(
-            "failed to get status for hash sequence object: {} {}",
-            hash_seq_hash,
-            e
-        )
-    })?;
-
-    let BlobStatus::Complete { size } = status else {
-        return Err(anyhow!(
-            "hash sequence object {} is not available",
-            hash_seq_hash
-        ));
-    };
-
-    if size.is_zero() {
-        return Err(anyhow!(
-            "hash sequence object {} has zero size",
-            hash_seq_hash
-        ));
-    }
-
-    let res = iroh
-        .blobs()
-        .read_to_bytes(hash_seq_hash)
-        .await
-        .map_err(|e| {
-            anyhow!(
-                "failed to read hash sequence object: {} {}",
-                hash_seq_hash,
-                e
-            )
-        })?;
-
-    let hash_seq = HashSeq::try_from(res).map_err(|e| {
-        anyhow!(
-            "failed to parse hash sequence object: {} {}",
-            hash_seq_hash,
-            e
-        )
-    })?;
-
-    let blob_hash = hash_seq.get(0).ok_or_else(|| {
-        anyhow!(
-            "failed to get hash with index 0 from hash sequence object: {}",
-            hash_seq_hash
-        )
-    })?;
-
-    let status = iroh
-        .blobs()
-        .status(blob_hash)
-        .await
-        .map_err(|e| anyhow!("failed to read object: {} {}", blob_hash, e))?;
-
-    let BlobStatus::Complete { size } = status else {
-        return Err(anyhow!("object {} is not available", blob_hash));
-    };
-    Ok((blob_hash, size))
-}
-
 /// Parse an f/eth-address from string.
 pub fn parse_address(s: &str) -> anyhow::Result<Address> {
     let addr = Network::Mainnet
@@ -886,6 +873,7 @@ mod tests {
     use super::*;
     use async_trait::async_trait;
     use bytes::Bytes;
+    use fendermint_actor_blobs_shared::state::Hash as BlobHash;
     use fendermint_vm_message::query::FvmQuery;
     use rand_chacha::rand_core::{RngCore, SeedableRng};
     use rand_chacha::ChaCha8Rng;
@@ -1019,7 +1007,7 @@ mod tests {
         let client_node_addr = client_iroh.net().node_addr().await.unwrap();
         let size = 11;
 
-        // Create multipart form for source-based upload
+        // Create the multipart form for source-based upload
         let boundary = "--abcdef1234--";
         let mut body = Vec::new();
         let form_data = format!(

--- a/fendermint/app/src/cmd/objects.rs
+++ b/fendermint/app/src/cmd/objects.rs
@@ -26,7 +26,7 @@ use iroh::{
     client::blobs::BlobStatus,
     net::NodeAddr,
 };
-use iroh_manager::{extract_blob_hash_and_size, IrohManager};
+use iroh_manager::{get_blob_hash_and_size, IrohManager};
 use lazy_static::lazy_static;
 use prometheus::{register_histogram, register_int_counter, Histogram, IntCounter};
 use serde::{Deserialize, Serialize};
@@ -649,7 +649,7 @@ async fn handle_object_download<F: QueryClient + Send + Sync>(
     match maybe_object {
         Some(object) => {
             let hash = Hash::from_bytes(object.hash.0);
-            let (hash, size) = extract_blob_hash_and_size(&iroh, hash).await.map_err(|e| {
+            let (hash, size) = get_blob_hash_and_size(&iroh, hash).await.map_err(|e| {
                 Rejection::from(BadRequest {
                     message: e.to_string(),
                 })

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -641,7 +641,7 @@ async fn dispatch_vote(
             }
         }
         AppVote::BlobFinality(f) => {
-            debug!(hash = ?f.hash, success = ?f.success, "received vote for blob finality");
+            debug!(hash = %f.hash, success = ?f.success, "received vote for blob finality");
             match atomically_or_err(|| {
                 parent_finality_votes.add_blob_vote(
                     vote.public_key.clone(),
@@ -676,7 +676,7 @@ async fn dispatch_vote(
             }
         }
         AppVote::ReadRequestClosed(r) => {
-            debug!(hash = ?r.hash, "received vote for read request completion");
+            debug!(hash = %r.hash, "received vote for read request completion");
             match atomically_or_err(|| {
                 parent_finality_votes.add_blob_vote(
                     vote.public_key.clone(),

--- a/fendermint/vm/interpreter/src/chain.rs
+++ b/fendermint/vm/interpreter/src/chain.rs
@@ -338,7 +338,7 @@ where
             state.state_tree_mut().begin_transaction();
             for item in local_finalized_blobs.iter() {
                 if is_blob_finalized(&mut state, item.subscriber, item.hash, item.id.clone())? {
-                    tracing::debug!(hash = ?item.hash, "blob already finalized on chain; removing from pool");
+                    tracing::debug!(hash = %item.hash, "blob already finalized on chain; removing from pool");
                     atomically(|| chain_env.blob_pool.remove_task(item)).await;
                     // Remove the result from the pool
                     atomically(|| chain_env.blob_pool.remove_result(item)).await;
@@ -351,7 +351,7 @@ where
                 })
                 .await;
                 if is_globally_finalized {
-                    tracing::debug!(hash = ?item.hash, size = item.size, "blob has quorum; adding tx to chain");
+                    tracing::debug!(hash = %item.hash, size = item.size, "blob has quorum; adding tx to chain");
                     blobs.push(ChainMessage::Ipc(IpcMessage::BlobFinalized(
                         FinalizedBlob {
                             subscriber: item.subscriber,
@@ -533,7 +533,7 @@ where
                     // Check that blobs that are being enqueued are still in "added" state in the actor
                     // Once we enqueue a blob, the actor will transition it to "pending" state.
                     if !is_blob_added(&mut state, blob.subscriber, blob.hash, blob.id)? {
-                        tracing::debug!(hash = ?blob.hash, "blob is not added onchain; rejecting proposal");
+                        tracing::debug!(hash = %blob.hash, "blob is not added onchain; rejecting proposal");
                         return Ok(false);
                     }
                 }
@@ -545,7 +545,7 @@ where
                         is_blob_finalized(state, blob.subscriber, blob.hash, blob.id.clone())
                     })?;
                     if is_blob_finalized {
-                        tracing::debug!(hash = ?blob.hash, "blob is already finalized on chain; rejecting proposal");
+                        tracing::debug!(hash = %blob.hash, "blob is already finalized on chain; rejecting proposal");
                         return Ok(false);
                     }
 
@@ -556,12 +556,12 @@ where
                     })
                     .await;
                     if !is_globally_finalized {
-                        tracing::debug!(hash = ?blob.hash, "blob is not globally finalized; rejecting proposal");
+                        tracing::debug!(hash = %blob.hash, "blob is not globally finalized; rejecting proposal");
                         return Ok(false);
                     }
                     if blob.succeeded != succeeded {
                         tracing::debug!(
-                            hash = ?blob.hash,
+                            hash = %blob.hash,
                             quorum = ?succeeded,
                             message = ?blob.succeeded,
                             "blob finalization mismatch; rejecting proposal"
@@ -584,12 +584,12 @@ where
                         })
                         .await;
                     if is_locally_finalized {
-                        tracing::debug!(hash = ?blob.hash, "blob is locally finalized; removing from pool");
+                        tracing::debug!(hash = %blob.hash, "blob is locally finalized; removing from pool");
                         atomically(|| chain_env.blob_pool.remove_task(&item)).await;
                         // Remove the result from the pool
                         atomically(|| chain_env.blob_pool.remove_result(&item)).await;
                     } else {
-                        tracing::debug!(hash = ?blob.hash, "blob is not locally finalized");
+                        tracing::debug!(hash = %blob.hash, "blob is not locally finalized");
                     }
                 }
                 ChainMessage::Ipc(IpcMessage::ReadRequestPending(read_request)) => {
@@ -608,7 +608,7 @@ where
                         get_read_request_status(state, read_request.id)
                     })?;
                     if !matches!(status, Some(ReadRequestStatus::Pending)) {
-                        tracing::info!(hash = ?read_request.id, "only pending read requests can be closed; rejecting proposal");
+                        tracing::info!(hash = %read_request.id, "only pending read requests can be closed; rejecting proposal");
                         return Ok(false);
                     }
 
@@ -626,7 +626,7 @@ where
                     })
                     .await;
                     if !is_globally_finalized {
-                        tracing::info!(hash = ?read_request.id, "read request is not globally finalized; rejecting proposal");
+                        tracing::info!(hash = %read_request.id, "read request is not globally finalized; rejecting proposal");
                         return Ok(false);
                     }
 
@@ -884,7 +884,7 @@ where
                     let (apply_ret, emitters) = state.execute_implicit(msg)?;
 
                     tracing::debug!(
-                        hash = ?blob.hash,
+                        hash = %blob.hash,
                         "chain interpreter has set blob to pending"
                     );
 
@@ -933,7 +933,7 @@ where
                     let (apply_ret, emitters) = state.execute_implicit(msg)?;
 
                     tracing::debug!(
-                        hash = ?blob.hash,
+                        hash = %blob.hash,
                         "chain interpreter has finalized blob"
                     );
 
@@ -985,7 +985,7 @@ where
                     let ret = close_read_request(&mut state, read_request.id)?;
 
                     tracing::debug!(
-                        hash = ?read_request.id,
+                        hash = %read_request.id,
                         "read request is closed"
                     );
 

--- a/fendermint/vm/iroh_resolver/src/iroh.rs
+++ b/fendermint/vm/iroh_resolver/src/iroh.rs
@@ -101,7 +101,7 @@ fn start_resolve<V>(
     V: Clone + Send + Sync + Serialize + DeserializeOwned + 'static,
 {
     tokio::spawn(async move {
-        tracing::debug!(hash = ?task.hash(), "starting iroh blob resolve");
+        tracing::debug!(hash = %task.hash(), "starting iroh blob resolve");
         match task.task_type() {
             TaskType::ResolveBlob { source, size } => {
                 match client
@@ -117,7 +117,7 @@ fn start_resolve<V>(
                         // By not quitting, we should see this error every time there is a new task, which is at least a constant reminder.
                     }
                     Ok(Ok(())) => {
-                        tracing::debug!(hash = ?task.hash(), "iroh blob resolved");
+                        tracing::debug!(hash = %task.hash(), "iroh blob resolved");
                         atomically(|| task.set_resolved()).await;
                         if add_own_vote(
                             task.hash(),
@@ -276,7 +276,7 @@ where
 async fn reenqueue(task: ResolveTask, queue: ResolveQueue, retry_delay: Duration) -> bool {
     if atomically(|| task.add_attempt()).await {
         tracing::error!(
-            hash = ?task.hash(),
+            hash = %task.hash(),
             "iroh blob resolution failed; retrying later"
         );
         schedule_retry(task, queue, retry_delay).await;

--- a/fendermint/vm/topdown/src/voting.rs
+++ b/fendermint/vm/topdown/src/voting.rs
@@ -444,6 +444,9 @@ where
                 } else {
                     power_table.get(vk).cloned().unwrap_or_default()
                 };
+
+                tracing::debug!("voter; key={}, power={}", vk.to_string(), power);
+
                 if *resolved {
                     resolved_weight += power;
                 } else {
@@ -451,6 +454,14 @@ where
                 }
             }
         }
+
+        tracing::debug!(
+            resolved_weight,
+            failed_weight,
+            quorum_threshold,
+            "blob quorum; votes={}",
+            votes_for_blob.len()
+        );
 
         if resolved_weight >= quorum_threshold {
             Ok((true, true))

--- a/ipld/resolver/Cargo.toml
+++ b/ipld/resolver/Cargo.toml
@@ -30,6 +30,7 @@ serde = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+uuid = { workspace = true }
 hex = { workspace = true }
 num-traits = { workspace = true }
 

--- a/ipld/resolver/Cargo.toml
+++ b/ipld/resolver/Cargo.toml
@@ -30,7 +30,6 @@ serde = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-uuid = { workspace = true }
 hex = { workspace = true }
 num-traits = { workspace = true }
 

--- a/ipld/resolver/Cargo.toml
+++ b/ipld/resolver/Cargo.toml
@@ -31,6 +31,7 @@ serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 hex = { workspace = true }
+num-traits = { workspace = true }
 
 fvm_ipld_encoding = { workspace = true }
 fvm_shared = { workspace = true }

--- a/ipld/resolver/src/service.rs
+++ b/ipld/resolver/src/service.rs
@@ -20,7 +20,7 @@ use iroh::blobs::Hash;
 use iroh::client::blobs::{BlobStatus, ReadAtLen};
 use iroh::client::Iroh;
 use iroh::net::NodeAddr;
-use iroh_manager::IrohManager;
+use iroh_manager::{extract_blob_hash_and_size, IrohManager};
 use libipld::store::StoreParams;
 use libipld::Cid;
 use libp2p::connection_limits::ConnectionLimits;
@@ -44,6 +44,7 @@ use tokio::select;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot::Sender;
+use uuid::Uuid;
 
 /// Result of attempting to resolve a CID.
 pub type ResolveResult = anyhow::Result<()>;
@@ -678,16 +679,15 @@ async fn download_blob(
     size: u64,
     node_addr: NodeAddr,
 ) -> anyhow::Result<()> {
+    // Download top-level blob
     // Use an explicit tag so we can keep track of it
-    // TODO: this needs to be tagged with a "user id"
     let tag = iroh::blobs::Tag(format!("stored-seq-{seq_hash}").into());
-    let res = iroh
-        .blobs()
+    iroh.blobs()
         .download_with_opts(
             seq_hash,
             iroh::client::blobs::DownloadOptions {
                 format: iroh::blobs::BlobFormat::Raw,
-                nodes: vec![node_addr],
+                nodes: vec![node_addr.clone()],
                 tag: iroh::blobs::util::SetTagOption::Named(tag),
                 mode: iroh::client::blobs::DownloadMode::Queued,
             },
@@ -695,19 +695,50 @@ async fn download_blob(
         .await?
         .await?;
 
-    let (_, size_actual) = extract_blob_hash_and_size(&iroh, seq_hash).await?;
-    if size != size_actual {
-        return Err(anyhow!(
-            "downloaded blob size {} does not match expected size {}",
-            size_actual,
-            size
-        ));
+    // Read top-level blob as a hash sequence
+    let res = iroh
+        .blobs()
+        .read_to_bytes(seq_hash)
+        .await
+        .map_err(|e| anyhow!("failed to read hash sequence object: {} {}", seq_hash, e))?;
+    let hash_seq = HashSeq::try_from(res)
+        .map_err(|e| anyhow!("failed to parse hash sequence object: {} {}", seq_hash, e))?;
+
+    // Download blobs in the hash sequence
+    for (i, hash) in hash_seq.iter().enumerate() {
+        let tmp_id = Uuid::new_v4();
+        let tmp_tag = iroh::blobs::Tag(format!("temp-{hash}-{tmp_id}").into());
+        let res = iroh
+            .blobs()
+            .download_with_opts(
+                hash,
+                iroh::client::blobs::DownloadOptions {
+                    format: iroh::blobs::BlobFormat::Raw,
+                    nodes: vec![node_addr.clone()],
+                    tag: iroh::blobs::util::SetTagOption::Named(tmp_tag.clone()),
+                    mode: iroh::client::blobs::DownloadMode::Queued,
+                },
+            )
+            .await?
+            .await?;
+        iroh.tags().delete(tmp_tag).await.ok();
+
+        // Verify user blob size
+        // The first hash in the sequence is the user blob for which we have the size
+        if i == 0 {
+            if res.local_size + res.downloaded_size != size {
+                return Err(anyhow!(
+                    "downloaded blob size {} does not match expected size {}",
+                    res.local_size + res.downloaded_size,
+                    size
+                ));
+            }
+        }
     }
 
-    debug!("downloaded blob {}: {:?}", seq_hash, res);
+    debug!("downloaded blob {}", seq_hash);
 
     // Delete the temporary tag (this might fail as not all nodes will have one).
-    // TODO: this needs to be tagged with a "user id"
     let tag = iroh::blobs::Tag(format!("temp-seq-{seq_hash}").into());
     iroh.tags().delete(tag).await.ok();
 
@@ -723,55 +754,4 @@ async fn read_blob(iroh: Iroh, hash: Hash, offset: u32, len: u32) -> anyhow::Res
         .await?;
     debug!("read blob {}: {:?}", hash, res);
     Ok(res)
-}
-
-async fn extract_blob_hash_and_size(
-    iroh: &Iroh,
-    seq_hash: Hash,
-) -> Result<(Hash, u64), anyhow::Error> {
-    let status = iroh.blobs().status(seq_hash).await.map_err(|e| {
-        anyhow!(
-            "failed to get status for hash sequence object: {} {}",
-            seq_hash,
-            e
-        )
-    })?;
-
-    let BlobStatus::Complete { size } = status else {
-        return Err(anyhow!(
-            "hash sequence object {} is not available",
-            seq_hash
-        ));
-    };
-
-    if size.is_zero() {
-        return Err(anyhow!("hash sequence object {} has zero size", seq_hash));
-    }
-
-    let res = iroh
-        .blobs()
-        .read_to_bytes(seq_hash)
-        .await
-        .map_err(|e| anyhow!("failed to read hash sequence object: {} {}", seq_hash, e))?;
-
-    let hash_seq = HashSeq::try_from(res)
-        .map_err(|e| anyhow!("failed to parse hash sequence object: {} {}", seq_hash, e))?;
-
-    let blob_hash = hash_seq.get(0).ok_or_else(|| {
-        anyhow!(
-            "failed to get hash with index 0 from hash sequence object: {}",
-            seq_hash
-        )
-    })?;
-
-    let status = iroh
-        .blobs()
-        .status(blob_hash)
-        .await
-        .map_err(|e| anyhow!("failed to read object: {} {}", blob_hash, e))?;
-
-    let BlobStatus::Complete { size } = status else {
-        return Err(anyhow!("object {} is not available", blob_hash));
-    };
-    Ok((blob_hash, size))
 }

--- a/ipld/resolver/src/service.rs
+++ b/ipld/resolver/src/service.rs
@@ -17,7 +17,7 @@ use ipc_api::subnet_id::SubnetID;
 use ipc_observability::emit;
 use iroh::blobs::hashseq::HashSeq;
 use iroh::blobs::Hash;
-use iroh::client::blobs::{BlobStatus, ReadAtLen};
+use iroh::client::blobs::ReadAtLen;
 use iroh::client::Iroh;
 use iroh::net::NodeAddr;
 use iroh_manager::{extract_blob_hash_and_size, IrohManager};
@@ -35,7 +35,6 @@ use libp2p::{identify, ping};
 use libp2p_bitswap::{BitswapResponse, BitswapStore};
 use libp2p_mplex::MplexConfig;
 use log::{debug, error, info, warn};
-use num_traits::Zero;
 use prometheus::Registry;
 use rand::seq::SliceRandom;
 use serde::de::DeserializeOwned;
@@ -725,14 +724,13 @@ async fn download_blob(
 
         // Verify user blob size
         // The first hash in the sequence is the user blob for which we have the size
-        if i == 0 {
-            if res.local_size + res.downloaded_size != size {
-                return Err(anyhow!(
-                    "downloaded blob size {} does not match expected size {}",
-                    res.local_size + res.downloaded_size,
-                    size
-                ));
-            }
+        let size_resolved = res.local_size + res.downloaded_size;
+        if i == 0 && size_resolved != size {
+            return Err(anyhow!(
+                "downloaded blob size {} does not match expected size {}",
+                size_resolved,
+                size
+            ));
         }
     }
 

--- a/recall/iroh_manager/Cargo.toml
+++ b/recall/iroh_manager/Cargo.toml
@@ -7,4 +7,5 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+num-traits = { workspace = true }
 iroh = { workspace = true }

--- a/recall/iroh_manager/src/lib.rs
+++ b/recall/iroh_manager/src/lib.rs
@@ -11,6 +11,7 @@ use iroh::client::blobs::BlobStatus;
 use iroh::client::Iroh;
 use num_traits::Zero;
 
+/// Helper for managing Iroh connections.
 #[derive(Clone, Debug)]
 pub struct IrohManager {
     addr: Option<String>,
@@ -18,10 +19,13 @@ pub struct IrohManager {
 }
 
 impl IrohManager {
+    /// Returns a manager for the address.
     pub fn from_addr(addr: Option<String>) -> IrohManager {
         Self { addr, client: None }
     }
 
+    /// Returns the Iroh client.
+    /// The underlying client will be created if it does not exist.  
     pub async fn client(&mut self) -> anyhow::Result<Iroh> {
         if let Some(c) = self.client.clone() {
             return Ok(c);
@@ -43,10 +47,13 @@ impl IrohManager {
     }
 }
 
-pub async fn extract_blob_hash_and_size(
+/// Returns the user blob hash and size from the hash sequence.
+/// The user blob hash is the first hash in the sequence.
+pub async fn get_blob_hash_and_size(
     iroh: &Iroh,
     seq_hash: Hash,
 ) -> Result<(Hash, u64), anyhow::Error> {
+    // Get the hash sequence status (it needs to be available)
     let status = iroh.blobs().status(seq_hash).await.map_err(|e| {
         anyhow!(
             "failed to get status for hash sequence object: {} {}",
@@ -54,42 +61,42 @@ pub async fn extract_blob_hash_and_size(
             e
         )
     })?;
-
     let BlobStatus::Complete { size } = status else {
         return Err(anyhow!(
             "hash sequence object {} is not available",
             seq_hash
         ));
     };
-
     if size.is_zero() {
         return Err(anyhow!("hash sequence object {} has zero size", seq_hash));
     }
 
+    // Read the bytes and create a hash sequence
     let res = iroh
         .blobs()
         .read_to_bytes(seq_hash)
         .await
         .map_err(|e| anyhow!("failed to read hash sequence object: {} {}", seq_hash, e))?;
-
     let hash_seq = HashSeq::try_from(res)
         .map_err(|e| anyhow!("failed to parse hash sequence object: {} {}", seq_hash, e))?;
 
+    // Get the user blob status at index 0 (it needs to be available)
     let blob_hash = hash_seq.get(0).ok_or_else(|| {
         anyhow!(
             "failed to get hash with index 0 from hash sequence object: {}",
             seq_hash
         )
     })?;
-
     let status = iroh
         .blobs()
         .status(blob_hash)
         .await
         .map_err(|e| anyhow!("failed to read object: {} {}", blob_hash, e))?;
 
+    // Finally, get the size from the status
     let BlobStatus::Complete { size } = status else {
         return Err(anyhow!("object {} is not available", blob_hash));
     };
+
     Ok((blob_hash, size))
 }

--- a/scripts/deploy_subnet/deploy.sh
+++ b/scripts/deploy_subnet/deploy.sh
@@ -520,8 +520,8 @@ cd "$IPC_FOLDER"
 # Approve each validator to stake
 for i in {0..2}
 do
-  # Approve power min 1 RECALL max 10 RECALL
-  cast send --private-key "$pk" --rpc-url "$rpc_url" --timeout 120 "$VALIDATOR_GATER_ADDRESS" "approve(address,uint256,uint256)" "${wallet_addresses[i]}" 1000000000000000000 100000000000000000000
+  # Approve power min 1 RECALL max 100 RECALL
+  cast send --private-key "$pk" --rpc-url "$rpc_url" --timeout 120 "$VALIDATOR_GATER_ADDRESS" "approve(address,uint256,uint256)" "${wallet_addresses[i]}" 1000000000000000000 1000000000000000000000
 done
 echo "Approved validators to stake"
 
@@ -589,7 +589,7 @@ do
   echo "Joining subnet ${subnet_id} for validator ${wallet_addresses[i]}"
   # Approve subnet contract to lock up to 10 RECALL from collateral contract (which is also the supply source contract)
   vpk=$(cat "${IPC_CONFIG_FOLDER}"/validator_"$i".sk)
-  cast send --private-key "$vpk" --rpc-url "$rpc_url" --timeout 120 "$SUPPLY_SOURCE_ADDRESS" "approve(address,uint256)" "$subnet_eth_addr" 10000000000000000000
+  cast send --private-key "$vpk" --rpc-url "$rpc_url" --timeout 120 "$SUPPLY_SOURCE_ADDRESS" "approve(address,uint256)" "$subnet_eth_addr" 100000000000000000000
   # Join and stake 10 RECALL
   ipc-cli subnet join --from "${wallet_addresses[i]}" --subnet "$subnet_id" --collateral 10
 done
@@ -827,7 +827,7 @@ if [[ $local_deploy = true ]]; then
     # transaction until it succeeds—else, we'll continue and simply skip the account since it's not
     # recommended to use the validator accounts during development, anyways
     while [ $attempt -le $max_retries ]; do
-      if cast send --rpc-url http://localhost:"${ETHAPI_HOST_PORTS[0]}" $CREDIT_MANAGER_ADDRESS "buyCredit()" --value "${credit_amount}ether" --private-key $private_key 2>/dev/null; then
+      if cast send --rpc-url http://localhost:"${ETHAPI_HOST_PORTS[0]}" "$CREDIT_MANAGER_ADDRESS" "buyCredit()" --value "${credit_amount}ether" --private-key "$private_key" 2>/dev/null; then
         echo "Successfully bought credits for account $i"
         break
       else
@@ -914,7 +914,7 @@ if [[ $local_deploy = true ]]; then
   echo "Parent RECALL:   ${parent_recall%.*} RECALL"
   echo "Subnet native:  ${subnet_native%.*} RECALL"
   # get credit balance (i.e., to help verify the credit purchases above worked)
-  account_info_output=$(cast call --rpc-url http://localhost:"${ETHAPI_HOST_PORTS[0]}" $CREDIT_MANAGER_ADDRESS "getAccount(address)" "${addr}")
+  account_info_output=$(cast call --rpc-url http://localhost:"${ETHAPI_HOST_PORTS[0]}" "$CREDIT_MANAGER_ADDRESS" "getAccount(address)" "${addr}")
   account_info=$(cast abi-decode "getAccount(address)((uint64,uint256,uint256,address,uint64,(address,(uint256,uint256,uint64,uint256,uint256))[],(address,(uint256,uint256,uint64,uint256,uint256))[],uint64,uint256))" "$account_info_output")
   credit_balance=$(echo "$account_info" | awk -F',' '{gsub(/[^0-9]/, "", $2); print substr($2, 1, length($2)-18)}')
   echo "Subnet credits: ${credit_balance}"


### PR DESCRIPTION
Four issues fixed here:
- The new size check during blob resolve was checking the top level hash seq hash size, not the internal blob hash size cc @avichalp 
- We also need to explicitly download using the hash sequence format during resolve in order to recursively download all hashes in the sequence.
- The buckets actor was trying to read a Cid for a HAMT that belongs to the blobs actor cc @joewagner 
- I added an `expiry` field to the bucket actors's `ObjectState` and some logic that will hide expired blobs when listing. 

Goes with https://github.com/recallnet/rust-recall/pull/238.