### PR TITLE
fix: preserve filetype/extension when downloading an object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3824,6 +3824,7 @@ dependencies = [
  "libp2p",
  "libp2p-bitswap",
  "literally",
+ "mime_guess",
  "multiaddr",
  "num-traits",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ libsecp256k1 = "0.7"
 literally = "0.1.3"
 log = "0.4"
 lru_time_cache = "0.11"
+mime_guess = { version = "2" , features = ["rev-mappings"]}
 multiaddr = "0.18"
 multihash = { version = "0.18.1", default-features = false, features = [
     "sha2",

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -25,6 +25,7 @@ libipld = { workspace = true }
 libp2p = { workspace = true }
 libp2p-bitswap = { workspace = true }
 literally = { workspace = true }
+mime_guess = { workspace = true }
 multiaddr = { workspace = true }
 num-traits = { workspace = true }
 openssl = { workspace = true }


### PR DESCRIPTION
# Summary

Closes https://github.com/recallnet/js-recall/issues/101

This PR adds the header `Content-Disposition` to the Objects API when downloading the object. It checks if the object's key has an extension, if so, it uses the object's key as the Content-Disposition's `filename`. If not, tries to guess based on content type.

# Notes
- This PR might fix Brave browser issue, but it will probably change the current behavior of other browsers. That is because the default `Content-Disposition` is `inline` and not `attachment`. So, before going forward with this we must decide on what behavior we want. 
- It is a bit hard to test now because of the download problem 
- I noticed we could improve the CLI to also check the extension to guess the content type. See https://github.com/recallnet/rust-recall/pull/235. Lmk if that makes sense