### PR TITLE
fix: make fendermint blobs types public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3550,6 +3550,7 @@ dependencies = [
  "fvm_shared",
  "num-derive 0.3.3",
  "num-traits",
+ "recall_actor_sdk",
  "recall_ipld",
  "serde",
 ]

--- a/fendermint/actors/blobs/shared/Cargo.toml
+++ b/fendermint/actors/blobs/shared/Cargo.toml
@@ -23,6 +23,7 @@ num-derive = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 
+recall_actor_sdk = { path = "../../../../recall/actor_sdk" }
 recall_ipld = { path = "../../../../recall/ipld" }
 
 [features]

--- a/fendermint/actors/blobs/shared/src/state.rs
+++ b/fendermint/actors/blobs/shared/src/state.rs
@@ -11,6 +11,7 @@ use fvm_shared::address::Address;
 use fvm_shared::bigint::{BigInt, BigUint};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
+use recall_actor_sdk::to_delegated_address;
 use recall_ipld::{hamt, hamt::map::TrackedFlushResult, hamt::MapKey};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -119,6 +120,66 @@ impl Account {
             approvals_to: CreditApprovals::new(store)?,
             approvals_from: CreditApprovals::new(store)?,
             gas_allowance: TokenAmount::default(),
+        })
+    }
+}
+
+/// The return type used for Account.
+#[derive(Debug, Serialize_tuple, Deserialize_tuple)]
+pub struct AccountInfo {
+    /// Total size of all blobs managed by the account.
+    pub capacity_used: u64,
+    /// Current free credit in byte-blocks that can be used for new commitments.
+    pub credit_free: Credit,
+    /// Current committed credit in byte-blocks that will be used for debits.
+    pub credit_committed: Credit,
+    /// Optional default sponsor account address.
+    pub credit_sponsor: Option<Address>,
+    /// The chain epoch of the last debit.
+    pub last_debit_epoch: ChainEpoch,
+    /// Credit approvals to other accounts from this account, keyed by receiver.
+    pub approvals_to: HashMap<Address, CreditApproval>,
+    /// Credit approvals to this account from other accounts, keyed by sender.
+    pub approvals_from: HashMap<Address, CreditApproval>,
+    /// The maximum allowed TTL for actor's blobs.
+    pub max_ttl: ChainEpoch,
+    /// The total token value an account has used to buy credits.
+    pub gas_allowance: TokenAmount,
+}
+
+impl AccountInfo {
+    pub fn from(rt: &impl Runtime, account: Account) -> Result<Self, ActorError> {
+        let store = rt.store();
+        let mut approvals_to = HashMap::new();
+        account
+            .approvals_to
+            .hamt(store)?
+            .for_each(|address, approval| {
+                let external_account_address = to_delegated_address(rt, address)?;
+                approvals_to.insert(external_account_address, approval.clone());
+                Ok(())
+            })?;
+
+        let mut approvals_from = HashMap::new();
+        account
+            .approvals_from
+            .hamt(store)?
+            .for_each(|address, approval| {
+                let external_account_address = to_delegated_address(rt, address)?;
+                approvals_from.insert(external_account_address, approval.clone());
+                Ok(())
+            })?;
+
+        Ok(AccountInfo {
+            capacity_used: account.capacity_used,
+            credit_free: account.credit_free,
+            credit_committed: account.credit_committed,
+            credit_sponsor: account.credit_sponsor,
+            last_debit_epoch: account.last_debit_epoch,
+            approvals_to,
+            approvals_from,
+            max_ttl: account.max_ttl,
+            gas_allowance: account.gas_allowance,
         })
     }
 }

--- a/fendermint/actors/blobs/src/actor.rs
+++ b/fendermint/actors/blobs/src/actor.rs
@@ -12,7 +12,7 @@ use fendermint_actor_blobs_shared::params::{
 use fendermint_actor_blobs_shared::state::{
     BlobInfo, BlobRequest, BlobStatus, Credit, CreditApproval, GasAllowance, Hash, Subscription,
 };
-use fendermint_actor_blobs_shared::Method;
+use fendermint_actor_blobs_shared::{state::AccountInfo, Method};
 use fendermint_actor_recall_config_shared::{get_config, require_caller_is_admin};
 use fil_actors_runtime::{
     actor_dispatch, actor_error, extract_send_result,
@@ -30,7 +30,6 @@ use recall_actor_sdk::{
 use crate::sol_facade::credit::{CreditApproved, CreditDebited, CreditPurchased, CreditRevoked};
 use crate::sol_facade::gas::{GasSponsorSet, GasSponsorUnset};
 use crate::sol_facade::{blobs as sol_blobs, credit as sol_credit, AbiCall, AbiCallRuntime};
-use crate::state::AccountInfo;
 use crate::{State, BLOBS_ACTOR_NAME};
 
 #[cfg(feature = "fil-actor")]

--- a/fendermint/actors/blobs/src/lib.rs
+++ b/fendermint/actors/blobs/src/lib.rs
@@ -8,4 +8,3 @@ mod sol_facade;
 mod state;
 
 pub use shared::*;
-pub use state::*;

--- a/fendermint/actors/blobs/src/sol_facade/credit.rs
+++ b/fendermint/actors/blobs/src/sol_facade/credit.rs
@@ -7,7 +7,7 @@ use fendermint_actor_blobs_shared::params::{
     ApproveCreditParams, BuyCreditParams, GetAccountParams, GetCreditApprovalParams,
     RevokeCreditParams, SetAccountStatusParams, SetSponsorParams,
 };
-use fendermint_actor_blobs_shared::state::{Credit, CreditApproval, TtlStatus};
+use fendermint_actor_blobs_shared::state::{AccountInfo, Credit, CreditApproval, TtlStatus};
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::{actor_error, ActorError};
 use fvm_shared::address::Address;
@@ -22,7 +22,6 @@ use std::collections::{HashMap, HashSet};
 pub use recall_sol_facade::credit::Calls;
 
 use crate::sol_facade::{AbiCall, AbiCallRuntime, AbiEncodeError};
-use crate::state::AccountInfo;
 
 pub struct CreditPurchased {
     from: Address,

--- a/fendermint/actors/blobs/src/state.rs
+++ b/fendermint/actors/blobs/src/state.rs
@@ -2,7 +2,7 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::error::Error;
 use std::fmt::Display;
 use std::str::from_utf8;
@@ -34,8 +34,6 @@ mod expiries;
 use accounts::AccountsState;
 use blobs::{BlobsProgressCollection, BlobsState};
 use expiries::{ExpiriesState, ExpiryUpdate};
-use fil_actors_runtime::runtime::Runtime;
-use recall_actor_sdk::to_delegated_address;
 
 /// The state represents all accounts and stored blobs.
 #[derive(Debug, Serialize_tuple, Deserialize_tuple)]
@@ -1799,66 +1797,6 @@ fn ensure_gas_limit(
         }
     }
     Ok(())
-}
-
-/// The return type used for Account.
-#[derive(Debug, Serialize_tuple, Deserialize_tuple)]
-pub struct AccountInfo {
-    /// Total size of all blobs managed by the account.
-    pub capacity_used: u64,
-    /// Current free credit in byte-blocks that can be used for new commitments.
-    pub credit_free: Credit,
-    /// Current committed credit in byte-blocks that will be used for debits.
-    pub credit_committed: Credit,
-    /// Optional default sponsor account address.
-    pub credit_sponsor: Option<Address>,
-    /// The chain epoch of the last debit.
-    pub last_debit_epoch: ChainEpoch,
-    /// Credit approvals to other accounts from this account, keyed by receiver.
-    pub approvals_to: HashMap<Address, CreditApproval>,
-    /// Credit approvals to this account from other accounts, keyed by sender.
-    pub approvals_from: HashMap<Address, CreditApproval>,
-    /// The maximum allowed TTL for actor's blobs.
-    pub max_ttl: ChainEpoch,
-    /// The total token value an account has used to buy credits.
-    pub gas_allowance: TokenAmount,
-}
-
-impl AccountInfo {
-    pub fn from(rt: &impl Runtime, account: Account) -> Result<Self, ActorError> {
-        let store = rt.store();
-        let mut approvals_to = HashMap::new();
-        account
-            .approvals_to
-            .hamt(store)?
-            .for_each(|address, approval| {
-                let external_account_address = to_delegated_address(rt, address)?;
-                approvals_to.insert(external_account_address, approval.clone());
-                Ok(())
-            })?;
-
-        let mut approvals_from = HashMap::new();
-        account
-            .approvals_from
-            .hamt(store)?
-            .for_each(|address, approval| {
-                let external_account_address = to_delegated_address(rt, address)?;
-                approvals_from.insert(external_account_address, approval.clone());
-                Ok(())
-            })?;
-
-        Ok(AccountInfo {
-            capacity_used: account.capacity_used,
-            credit_free: account.credit_free,
-            credit_committed: account.credit_committed,
-            credit_sponsor: account.credit_sponsor,
-            last_debit_epoch: account.last_debit_epoch,
-            approvals_to,
-            approvals_from,
-            max_ttl: account.max_ttl,
-            gas_allowance: account.gas_allowance,
-        })
-    }
 }
 
 #[cfg(test)]

--- a/recall/ipld/src/hamt.rs
+++ b/recall/ipld/src/hamt.rs
@@ -6,8 +6,8 @@
 mod core;
 pub mod map;
 
-pub use core::DEFAULT_HAMT_CONFIG;
-pub use core::MapKey;
 pub use core::Map;
+pub use core::MapKey;
+pub use core::DEFAULT_HAMT_CONFIG;
 pub use fvm_ipld_hamt::{BytesKey, Error};
 pub use map::Root;


### PR DESCRIPTION
The changes in #582 moved the `AccountInfo` type from the `fendermint_blobs_shared` packages to the `fendermint_blobs` package.  This type is needed by the rust SDK, and the move made the type private.  
The change in this PR makes the `fendermint_blobs::state` module public, so the SDK can access it.
Related PR for the SDK is here: https://github.com/recallnet/rust-recall/pull/256