### PR TITLE
fix: download of key with different delimiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3854,6 +3854,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "urlencoding",
  "uuid 1.15.1",
  "warp",
 ]
@@ -13554,6 +13555,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,6 +200,7 @@ tracing-subscriber = { version = "0.3", features = [
 tracing-appender = "0.2.3"
 uuid = { version = "1.15.1", features = ["v4"] }
 url = { version = "2.4.1", features = ["serde"] }
+urlencoding = "2.1"
 warp = "0.3.7"
 zeroize = "1.6"
 

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -49,6 +49,7 @@ tower-abci = { workspace = true }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
+urlencoding = { workspace = true }
 uuid = { workspace = true }
 warp = { workspace = true }
 


### PR DESCRIPTION
# Summary 

Closes #596 

We must assume that the object key can be url-encoded, so we must try decoding the key.

Note:
- SDKs must be changed to make sure keys are url-encoded

cc @dtbuchholz in case there is something in docs that must be changed