### PR TITLE
fix: calling wasm actor from eth

### DIFF
--- a/fendermint/eth/api/src/conv/from_tm.rs
+++ b/fendermint/eth/api/src/conv/from_tm.rs
@@ -295,11 +295,8 @@ pub async fn to_eth_receipt(
         transaction_index,
         block_hash: Some(block_hash),
         block_number: Some(block_number),
-        from: to_eth_address(&msg.from, true)
-            .ok()
-            .flatten()
-            .unwrap_or_default(),
-        to: to_eth_address(&msg.to, true).ok().flatten(),
+        from: to_eth_address(&msg.from).ok().flatten().unwrap_or_default(),
+        to: to_eth_address(&msg.to).ok().flatten(),
         cumulative_gas_used,
         gas_used: Some(et::U256::from(result.tx_result.gas_used)),
         contract_address,
@@ -465,7 +462,7 @@ pub fn to_logs(
             .ok_or_else(|| anyhow!("cannot find the 'emitter.id' key"))?;
 
         let address = addr
-            .and_then(|a| to_eth_address(&a, true).ok())
+            .and_then(|a| to_eth_address(&a).ok())
             .flatten()
             .unwrap_or_else(|| et::H160::from(EthAddress::from_id(actor_id).0));
 

--- a/fendermint/testing/materializer/tests/docker_tests/layer2.rs
+++ b/fendermint/testing/materializer/tests/docker_tests/layer2.rs
@@ -62,7 +62,7 @@ async fn test_topdown_and_bottomup() {
 
                 // Subnet actor on the parent
                 let england_subnet = SubnetActorGetterFacet::new(
-                    to_eth_address(&england.subnet_id.subnet_actor(), true)
+                    to_eth_address(&england.subnet_id.subnet_actor())
                         .and_then(|a| a.ok_or_else(|| anyhow!("not an eth address")))?,
                     brussels_provider.clone(),
                 );

--- a/fendermint/vm/message/src/conv/from_fvm.rs
+++ b/fendermint/vm/message/src/conv/from_fvm.rs
@@ -35,7 +35,7 @@ pub fn to_eth_tokens(amount: &TokenAmount) -> anyhow::Result<et::U256> {
     }
 }
 
-pub fn to_eth_address(addr: &Address, allow_masked: bool) -> anyhow::Result<Option<et::H160>> {
+pub fn to_eth_address(addr: &Address) -> anyhow::Result<Option<et::H160>> {
     match addr.payload() {
         Payload::Delegated(d) if d.namespace() == EAM_ACTOR_ID && d.subaddress().len() == 20 => {
             Ok(Some(et::H160::from_slice(d.subaddress())))
@@ -43,9 +43,7 @@ pub fn to_eth_address(addr: &Address, allow_masked: bool) -> anyhow::Result<Opti
         // Deployments should be sent with an empty `to`.
         Payload::ID(EAM_ACTOR_ID) => Ok(None),
         // It should be possible to send to an ethereum account by ID.
-        Payload::ID(id) if allow_masked => {
-            Ok(Some(et::H160::from_slice(&EthAddress::from_id(*id).0)))
-        }
+        Payload::ID(id) => Ok(Some(et::H160::from_slice(&EthAddress::from_id(*id).0))),
         // The following fit into the type but are not valid ethereum addresses.
         // Return an error so we can prevent tampering with the address when we convert ethereum transactions to FVM messages.
         _ => bail!("not an Ethereum address: {addr}"), // f1, f2, f3 or an invalid delegated address.
@@ -108,7 +106,7 @@ pub fn to_eth_legacy_request(
     } = msg;
 
     let mut tx = et::TransactionRequest::new()
-        .from(to_eth_address(from, true)?.unwrap_or_default())
+        .from(to_eth_address(from)?.unwrap_or_default())
         .nonce(*sequence)
         .gas(*gas_limit)
         .gas_price(to_eth_tokens(gas_fee_cap)?)
@@ -128,7 +126,7 @@ pub fn to_eth_legacy_request(
         tx = tx.data(et::Bytes::from(data));
     }
 
-    tx.to = to_eth_address(to, true)?.map(et::NameOrAddress::Address);
+    tx.to = to_eth_address(to)?.map(et::NameOrAddress::Address);
 
     // NOTE: It's impossible to tell if the original Ethereum transaction sent None or Some(0).
     // The ethers deployer sends None, so let's assume that's the useful behavour to match.
@@ -170,14 +168,14 @@ pub fn to_eth_eip1559_request(
 
     let mut tx = et::Eip1559TransactionRequest::new()
         .chain_id(chain_id)
-        .from(to_eth_address(from, true)?.unwrap_or_default())
+        .from(to_eth_address(from)?.unwrap_or_default())
         .nonce(*sequence)
         .gas(*gas_limit)
         .max_fee_per_gas(to_eth_tokens(gas_fee_cap)?)
         .max_priority_fee_per_gas(to_eth_tokens(gas_premium)?)
         .data(et::Bytes::from(data));
 
-    tx.to = to_eth_address(to, true)?.map(et::NameOrAddress::Address);
+    tx.to = to_eth_address(to)?.map(et::NameOrAddress::Address);
 
     // NOTE: It's impossible to tell if the original Ethereum transaction sent None or Some(0).
     // The ethers deployer sends None, so let's assume that's the useful behavour to match.


### PR DESCRIPTION
Fixes calling a WASM actor from an Ethereum address, which is currently required by the Rust SDK.