### PR TITLE
fix: syscall rpc connect addr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10374,8 +10374,6 @@ version = "0.1.0"
 dependencies = [
  "fvm",
  "fvm_shared",
- "hex",
- "iroh",
  "iroh-blobs",
  "iroh_manager",
  "recall_kernel_ops",

--- a/recall/syscalls/Cargo.toml
+++ b/recall/syscalls/Cargo.toml
@@ -11,8 +11,6 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fvm = { workspace = true }
 fvm_shared = { workspace = true }
-hex = { workspace = true }
-iroh = { workspace = true }
 iroh-blobs = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
The local connect address was changed to "all available IP addresses" (`0.0.0.0`). Client's need a real IP address to connect. In the case of the syscall, this can be loopback since it's in the same process / container. 