### PR TITLE
feat: tune observability log level

### DIFF
--- a/fendermint/app/src/observe.rs
+++ b/fendermint/app/src/observe.rs
@@ -27,7 +27,7 @@ register_metrics! {
 }
 
 impl_traceables!(
-    TraceLevel::Info,
+    TraceLevel::Debug,
     "Consensus",
     BlockProposalReceived<'a>,
     BlockProposalSent<'a>,
@@ -35,7 +35,7 @@ impl_traceables!(
     BlockCommitted
 );
 
-impl_traceables!(TraceLevel::Info, "Mpool", MpoolReceived);
+impl_traceables!(TraceLevel::Debug, "Mpool", MpoolReceived);
 
 pub type BlockHeight = u64;
 

--- a/fendermint/vm/interpreter/src/fvm/check.rs
+++ b/fendermint/vm/interpreter/src/fvm/check.rs
@@ -55,7 +55,7 @@ where
                        gas_used: Option<u64>,
                        return_data: Option<RawBytes>,
                        info: Option<String>| {
-            tracing::info!(
+            tracing::debug!(
                 exit_code = exit_code.value(),
                 from = msg.from.to_string(),
                 to = msg.to.to_string(),

--- a/fendermint/vm/interpreter/src/fvm/checkpoint.rs
+++ b/fendermint/vm/interpreter/src/fvm/checkpoint.rs
@@ -318,7 +318,7 @@ where
         .context("failed to broadcast signature")?;
 
     // The transaction should be in the mempool now.
-    tracing::info!(tx_hash = tx_hash.to_string(), "broadcasted signature");
+    tracing::debug!(tx_hash = tx_hash.to_string(), "broadcasted signature");
 
     Ok(())
 }

--- a/fendermint/vm/interpreter/src/fvm/observe.rs
+++ b/fendermint/vm/interpreter/src/fvm/observe.rs
@@ -40,7 +40,7 @@ register_metrics! {
         = register_int_gauge!("bottomup_checkpoint_finalized_height", "Height of the checkpoint finalized");
 }
 
-impl_traceables!(TraceLevel::Info, "Execution", MsgExec);
+impl_traceables!(TraceLevel::Debug, "Execution", MsgExec);
 
 #[derive(Debug, strum::EnumString)]
 #[strum(serialize_all = "snake_case")]
@@ -75,7 +75,7 @@ impl Recordable for MsgExec {
 }
 
 impl_traceables!(
-    TraceLevel::Info,
+    TraceLevel::Debug,
     "Bottomup",
     CheckpointCreated,
     CheckpointSigned,

--- a/fendermint/vm/interpreter/src/fvm/query.rs
+++ b/fendermint/vm/interpreter/src/fvm/query.rs
@@ -55,7 +55,7 @@ where
         match qry {
             FvmQuery::Ipld(cid) => {
                 let data = state.store_get(&cid)?;
-                tracing::info!(
+                tracing::debug!(
                     height = state.block_height(),
                     pending = state.pending(),
                     cid = cid.to_string(),
@@ -67,7 +67,7 @@ where
             }
             FvmQuery::ActorState(address) => {
                 let (state, ret) = state.actor_state(&address).await?;
-                tracing::info!(
+                tracing::debug!(
                     height = state.block_height(),
                     pending = state.pending(),
                     addr = address.to_string(),
@@ -110,7 +110,7 @@ where
                 Ok((state, out))
             }
             FvmQuery::EstimateGas(mut msg) => {
-                tracing::info!(
+                tracing::debug!(
                     height = state.block_height(),
                     pending = state.pending(),
                     to = msg.to.to_string(),

--- a/fendermint/vm/interpreter/src/fvm/state/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/exec.rs
@@ -35,6 +35,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::fmt;
 use tendermint::consensus::params::Params as TendermintConsensusParams;
+use tracing::Level;
 
 pub type BlockHash = [u8; 32];
 
@@ -172,8 +173,9 @@ where
         params: FvmStateParams,
     ) -> anyhow::Result<Self> {
         let mut nc = NetworkConfig::new(params.network_version);
-        // TODO (findme): Make this configurable
-        nc.enable_actor_debugging();
+        if tracing::enabled!(Level::DEBUG) {
+            nc.enable_actor_debugging();
+        }
         nc.chain_id = ChainID::from(params.chain_id);
 
         // TODO: Configure:

--- a/fendermint/vm/iroh_resolver/src/observe.rs
+++ b/fendermint/vm/iroh_resolver/src/observe.rs
@@ -44,7 +44,7 @@ register_metrics! {
 }
 
 impl_traceables!(
-    TraceLevel::Info,
+    TraceLevel::Debug,
     "IrohResolver",
     BlobsFinalityVotingFailure,
     BlobsFinalityVotingSuccess,

--- a/fendermint/vm/topdown/src/observe.rs
+++ b/fendermint/vm/topdown/src/observe.rs
@@ -36,7 +36,7 @@ register_metrics! {
 }
 
 impl_traceables!(
-    TraceLevel::Info,
+    TraceLevel::Debug,
     "Topdown",
     ParentRpcCalled<'a>,
     ParentFinalityAcquired<'a>,


### PR DESCRIPTION
Log observability tracing events with log level `DEBUG` to have the `INFO` log stream clean.

Close #605 