### PR TITLE
fix: handle facade 'queryObjects' & empty 'starKey'

### DIFF
--- a/fendermint/actors/bucket/src/sol_facade.rs
+++ b/fendermint/actors/bucket/src/sol_facade.rs
@@ -256,7 +256,7 @@ fn sol_query(list: ListObjectsReturn) -> sol::Query {
 }
 
 const DEFAULT_DELIMITER: &[u8] = b"/"; // "/" in ASCII and UTF-8
-const DEFAULT_START_KEY: Vec<u8> = vec![]; //= ""
+const DEFAULT_START_KEY: Option<Vec<u8>> = None; //= ""
 const DEFAULT_PREFIX: Vec<u8> = vec![]; //= ""
 const DEFAULT_LIMIT: u64 = 0;
 
@@ -268,12 +268,16 @@ impl AbiCall for sol::queryObjects_0Call {
     fn params(&self) -> Self::Params {
         let prefix = self.prefix.clone().into_bytes();
         let delimiter = self.delimiter.clone().into_bytes();
-        let start_key = self.startKey.clone().into_bytes();
+        let start_key = if self.startKey.clone().is_empty() {
+            None
+        } else {
+            Some(self.startKey.clone().into_bytes())
+        };
         let limit = self.limit;
         ListParams {
             prefix,
             delimiter,
-            start_key: Some(start_key),
+            start_key,
             limit,
         }
     }
@@ -292,12 +296,16 @@ impl AbiCall for sol::queryObjects_1Call {
     fn params(&self) -> Self::Params {
         let prefix = self.prefix.clone().into_bytes();
         let delimiter = self.delimiter.clone().into_bytes();
-        let start_key = self.startKey.clone().into_bytes();
+        let start_key = if self.startKey.clone().is_empty() {
+            None
+        } else {
+            Some(self.startKey.clone().into_bytes())
+        };
         let limit = DEFAULT_LIMIT;
         ListParams {
             prefix,
             delimiter,
-            start_key: Some(start_key),
+            start_key,
             limit,
         }
     }
@@ -321,7 +329,7 @@ impl AbiCall for sol::queryObjects_2Call {
         ListParams {
             prefix,
             delimiter,
-            start_key: Some(start_key),
+            start_key,
             limit,
         }
     }
@@ -340,12 +348,12 @@ impl AbiCall for sol::queryObjects_3Call {
     fn params(&self) -> Self::Params {
         let prefix = DEFAULT_PREFIX;
         let delimiter = DEFAULT_DELIMITER.to_vec();
-        let start_key = DEFAULT_START_KEY.to_vec();
+        let start_key = DEFAULT_START_KEY;
         let limit = 0;
         ListParams {
             prefix,
             delimiter,
-            start_key: Some(start_key),
+            start_key,
             limit,
         }
     }
@@ -369,7 +377,7 @@ impl AbiCall for sol::queryObjects_4Call {
         ListParams {
             prefix,
             delimiter,
-            start_key: Some(start_key),
+            start_key,
             limit,
         }
     }

--- a/fendermint/actors/bucket/src/sol_facade.rs
+++ b/fendermint/actors/bucket/src/sol_facade.rs
@@ -268,7 +268,7 @@ impl AbiCall for sol::queryObjects_0Call {
     fn params(&self) -> Self::Params {
         let prefix = self.prefix.clone().into_bytes();
         let delimiter = self.delimiter.clone().into_bytes();
-        let start_key = if self.startKey.clone().is_empty() {
+        let start_key = if self.startKey.is_empty() {
             None
         } else {
             Some(self.startKey.clone().into_bytes())
@@ -296,7 +296,7 @@ impl AbiCall for sol::queryObjects_1Call {
     fn params(&self) -> Self::Params {
         let prefix = self.prefix.clone().into_bytes();
         let delimiter = self.delimiter.clone().into_bytes();
-        let start_key = if self.startKey.clone().is_empty() {
+        let start_key = if self.startKey.is_empty() {
             None
         } else {
             Some(self.startKey.clone().into_bytes())


### PR DESCRIPTION
## Summary

Closes https://github.com/recallnet/ipc/issues/616

## Details

Build `ipc`, and then test with the following:
1. Set up env vars, and then add an object to the bucket
```
BUCKET_ADDR=$(recall bu create | jq '.address' | tr -d '"')
export ETH_RPC_URL=http://localhost:8645
echo 'hello' > ~/hello.txt
recall bu add --address $BUCKET_ADDR --key hello/world ~/hello.txt
```
2. run `cast` queries for each overload:
```
cast abi-decode "queryObjects(string,string,string,uint64)(((string,(bytes32,uint64,uint64,(string,string)[]))[],string[],string))" $(cast call --rpc-url $ETH_RPC_URL $BUCKET_ADDR "queryObjects(string,string,string,uint64)" "hello/world" "/" "hello/world" 1)

cast abi-decode "queryObjects(string,string,string)(((string,(bytes32,uint64,uint64,(string,string)[]))[],string[],string))" $(cast call --rpc-url $ETH_RPC_URL $BUCKET_ADDR "queryObjects(string,string,string)" "hello/world" "/" "hello/world")

cast abi-decode "queryObjects(string,string)(((string,(bytes32,uint64,uint64,(string,string)[]))[],string[],string))" $(cast call --rpc-url $ETH_RPC_URL $BUCKET_ADDR "queryObjects(string,string)" "hello/world" "/")

cast abi-decode "queryObjects()(((string,(bytes32,uint64,uint64,(string,string)[]))[],string[],string))" $(cast call --rpc-url $ETH_RPC_URL $BUCKET_ADDR "queryObjects()")
```