### PR TITLE
Fix Typos in Documentation Comments Across Multiple Modules

### DIFF
--- a/fendermint/crypto/src/lib.rs
+++ b/fendermint/crypto/src/lib.rs
@@ -10,7 +10,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 pub use libsecp256k1::{PublicKey, RecoveryId, Signature};
 
 /// A [`GeneralPurpose`] engine using the [`alphabet::STANDARD`] base64 alphabet
-/// padding bytes when writing but requireing no padding when reading.
+/// padding bytes when writing but requiring no padding when reading.
 const B64_ENGINE: GeneralPurpose = GeneralPurpose::new(
     &alphabet::STANDARD,
     GeneralPurposeConfig::new()

--- a/fendermint/rocksdb/src/kvstore.rs
+++ b/fendermint/rocksdb/src/kvstore.rs
@@ -322,7 +322,7 @@ mod tests {
         db
     }
 
-    // Not using the `#[quickcheck]` macro so I can run fewer tests becasue they are slow.
+    // Not using the `#[quickcheck]` macro so I can run fewer tests because they are slow.
     fn run_quickcheck<F: Testable>(f: F) {
         QuickCheck::new().tests(TEST_COUNT).quickcheck(f)
     }

--- a/fendermint/testing/contract-test/src/ipc/registry.rs
+++ b/fendermint/testing/contract-test/src/ipc/registry.rs
@@ -42,7 +42,7 @@ impl<DB> RegistryCaller<DB> {
 }
 
 impl<DB: Blockstore + Clone> RegistryCaller<DB> {
-    /// Create a new instance of the built-in subnet implemetation.
+    /// Create a new instance of the built-in subnet implementation.
     ///
     /// Returns the address of the deployed contract.
     pub fn new_subnet(


### PR DESCRIPTION


Description:  
This pull request corrects minor typographical errors in documentation comments across several modules:

- In `fendermint/crypto/src/lib.rs`, fixed the spelling of "requiring" in the base64 engine comment.
- In `fendermint/rocksdb/src/kvstore.rs`, fixed the spelling of "because" in a test-related comment.
- In `fendermint/testing/contract-test/src/ipc/registry.rs`, fixed the spelling of "implementation" in a function comment.

These changes are documentation-only and do not affect any code logic or functionality.
